### PR TITLE
Evdev

### DIFF
--- a/etc/mtree/BSD.include.dist
+++ b/etc/mtree/BSD.include.dist
@@ -110,6 +110,8 @@
         ..
         ciss
         ..
+        evdev
+        ..
         filemon
         ..
         firewire

--- a/include/Makefile
+++ b/include/Makefile
@@ -154,7 +154,7 @@ copies: .PHONY .META
 		done; \
 	fi
 .endfor
-.for i in ${LDIRS} ${LSUBDIRS:Ndev/agp:Ndev/acpica:Ndev/bktr:Ndev/nand:Ndev/pci} ${LSUBSUBDIRS}
+.for i in ${LDIRS} ${LSUBDIRS:Ndev/agp:Ndev/acpica:Ndev/bktr:Ndev/evdev:Ndev/nand:Ndev/pci} ${LSUBSUBDIRS}
 	cd ${.CURDIR}/../sys; \
 	${INSTALL} -C ${TAG_ARGS} -o ${BINOWN} -g ${BINGRP} -m 444 $i/*.h \
 	    ${DESTDIR}${INCLUDEDIR}/$i
@@ -177,6 +177,11 @@ copies: .PHONY .META
 	${INSTALL} -C ${TAG_ARGS} -o ${BINOWN} -g ${BINGRP} -m 444 nand_dev.h \
 	    ${DESTDIR}${INCLUDEDIR}/dev/nand
 .endif
+	cd ${.CURDIR}/../sys/dev/evdev; \
+	${INSTALL} -C -o ${BINOWN} -g ${BINGRP} -m 444 input.h \
+	    ${DESTDIR}${INCLUDEDIR}/dev/evdev; \
+	${INSTALL} -C -o ${BINOWN} -g ${BINGRP} -m 444 uinput.h \
+	    ${DESTDIR}${INCLUDEDIR}/dev/evdev
 	cd ${.CURDIR}/../sys/dev/pci; \
 	${INSTALL} -C ${TAG_ARGS} -o ${BINOWN} -g ${BINGRP} -m 444 pcireg.h \
 	    ${DESTDIR}${INCLUDEDIR}/dev/pci
@@ -238,7 +243,7 @@ symlinks: .PHONY .META
 		${INSTALL_SYMLINK} ${TAG_ARGS} ../../../sys/$i/$$h ${DESTDIR}${INCLUDEDIR}/$i; \
 	done
 .endfor
-.for i in ${LSUBDIRS:Ndev/agp:Ndev/acpica:Ndev/bktr:Ndev/nand:Ndev/pci}
+.for i in ${LSUBDIRS:Ndev/agp:Ndev/acpica:Ndev/bktr:Ndev/evdev:Ndev/nand:Ndev/pci}
 	cd ${.CURDIR}/../sys/$i; \
 	for h in *.h; do \
 		${INSTALL_SYMLINK} ${TAG_ARGS} ../../../../sys/$i/$$h ${DESTDIR}${INCLUDEDIR}/$i; \
@@ -266,6 +271,11 @@ symlinks: .PHONY .META
 		    ${DESTDIR}${INCLUDEDIR}/dev/nand; \
 	done
 .endif
+	cd ${.CURDIR}/../sys/dev/evdev; \
+	for h in input.h uinput.h; do \
+		ln -fs ../../../../sys/dev/evdev/$$h \
+		    ${DESTDIR}${INCLUDEDIR}/dev/evdev; \
+	done
 	cd ${.CURDIR}/../sys/dev/pci; \
 	for h in pcireg.h; do \
 		${INSTALL_SYMLINK} ${TAG_ARGS} ../../../../sys/dev/pci/$$h \

--- a/sys/amd64/conf/EVDEV
+++ b/sys/amd64/conf/EVDEV
@@ -1,0 +1,374 @@
+#
+# GENERIC -- Generic kernel configuration file for FreeBSD/amd64
+#
+# For more information on this file, please read the config(5) manual page,
+# and/or the handbook section on Kernel Configuration Files:
+#
+#    http://www.FreeBSD.org/doc/en_US.ISO8859-1/books/handbook/kernelconfig-config.html
+#
+# The handbook is also available locally in /usr/share/doc/handbook
+# if you've installed the doc distribution, otherwise always see the
+# FreeBSD World Wide Web server (http://www.FreeBSD.org/) for the
+# latest information.
+#
+# An exhaustive list of options and more detailed explanations of the
+# device lines is also present in the ../../conf/NOTES and NOTES files.
+# If you are in doubt as to the purpose or necessity of a line, check first
+# in NOTES.
+#
+# $FreeBSD$
+
+cpu		HAMMER
+ident		GENERIC
+
+makeoptions	DEBUG=-g		# Build kernel with gdb(1) debug symbols
+makeoptions	WITH_CTF=1		# Run ctfconvert(1) for DTrace support
+
+options 	SCHED_ULE		# ULE scheduler
+options 	PREEMPTION		# Enable kernel thread preemption
+options 	INET			# InterNETworking
+options 	INET6			# IPv6 communications protocols
+options 	IPSEC			# IP (v4/v6) security
+options 	TCP_OFFLOAD		# TCP offload
+options 	SCTP			# Stream Control Transmission Protocol
+options 	FFS			# Berkeley Fast Filesystem
+options 	SOFTUPDATES		# Enable FFS soft updates support
+options 	UFS_ACL			# Support for access control lists
+options 	UFS_DIRHASH		# Improve performance on big directories
+options 	UFS_GJOURNAL		# Enable gjournal-based UFS journaling
+options 	QUOTA			# Enable disk quotas for UFS
+options 	MD_ROOT			# MD is a potential root device
+options 	NFSCL			# Network Filesystem Client
+options 	NFSD			# Network Filesystem Server
+options 	NFSLOCKD		# Network Lock Manager
+options 	NFS_ROOT		# NFS usable as /, requires NFSCL
+options 	MSDOSFS			# MSDOS Filesystem
+options 	CD9660			# ISO 9660 Filesystem
+options 	PROCFS			# Process filesystem (requires PSEUDOFS)
+options 	PSEUDOFS		# Pseudo-filesystem framework
+options 	GEOM_PART_GPT		# GUID Partition Tables.
+options 	GEOM_RAID		# Soft RAID functionality.
+options 	GEOM_LABEL		# Provides labelization
+options 	COMPAT_FREEBSD32	# Compatible with i386 binaries
+options 	COMPAT_FREEBSD4		# Compatible with FreeBSD4
+options 	COMPAT_FREEBSD5		# Compatible with FreeBSD5
+options 	COMPAT_FREEBSD6		# Compatible with FreeBSD6
+options 	COMPAT_FREEBSD7		# Compatible with FreeBSD7
+options 	COMPAT_FREEBSD9		# Compatible with FreeBSD9
+options 	COMPAT_FREEBSD10	# Compatible with FreeBSD10
+options 	SCSI_DELAY=5000		# Delay (in ms) before probing SCSI
+options 	KTRACE			# ktrace(1) support
+options 	STACK			# stack(9) support
+options 	SYSVSHM			# SYSV-style shared memory
+options 	SYSVMSG			# SYSV-style message queues
+options 	SYSVSEM			# SYSV-style semaphores
+options 	_KPOSIX_PRIORITY_SCHEDULING # POSIX P1003_1B real-time extensions
+options 	PRINTF_BUFR_SIZE=128	# Prevent printf output being interspersed.
+options 	KBD_INSTALL_CDEV	# install a CDEV entry in /dev
+options 	HWPMC_HOOKS		# Necessary kernel hooks for hwpmc(4)
+options 	AUDIT			# Security event auditing
+options 	CAPABILITY_MODE		# Capsicum capability mode
+options 	CAPABILITIES		# Capsicum capabilities
+options 	MAC			# TrustedBSD MAC Framework
+options 	KDTRACE_FRAME		# Ensure frames are compiled in
+options 	KDTRACE_HOOKS		# Kernel DTrace hooks
+options 	DDB_CTF			# Kernel ELF linker loads CTF data
+options 	INCLUDE_CONFIG_FILE	# Include this file in kernel
+options 	RACCT			# Resource accounting framework
+options 	RACCT_DEFAULT_TO_DISABLED # Set kern.racct.enable=0 by default
+options 	RCTL			# Resource limits
+
+# Debugging support.  Always need this:
+options 	KDB			# Enable kernel debugger support.
+options 	KDB_TRACE		# Print a stack trace for a panic.
+# For full debugger support use (turn off in stable branch):
+options 	DDB			# Support DDB.
+options 	GDB			# Support remote GDB.
+options 	DEADLKRES		# Enable the deadlock resolver
+options 	INVARIANTS		# Enable calls of extra sanity checking
+options 	INVARIANT_SUPPORT	# Extra sanity checks of internal structures, required by INVARIANTS
+#options		DEBUG_MEMGUARD
+#options		DEBUG_REDZONE
+options 	WITNESS			# Enable checks to detect deadlocks and cycles
+options		WITNESS_ALL
+options 	WITNESS_SKIPSPIN	# Don't run witness on spinlocks for speed
+options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
+
+# Make an SMP-capable kernel by default
+options 	SMP			# Symmetric MultiProcessor Kernel
+options 	DEVICE_NUMA		# I/O Device Affinity
+
+options		EVDEV
+
+# CPU frequency control
+device		cpufreq
+
+# Bus support.
+device		acpi
+options 	ACPI_DMAR
+device		pci
+options 	PCI_HP			# PCI-Express native HotPlug
+options		PCI_IOV			# PCI SR-IOV support
+
+# Floppy drives
+device		fdc
+
+# ATA controllers
+device		ahci			# AHCI-compatible SATA controllers
+device		ata			# Legacy ATA/SATA controllers
+device		mvs			# Marvell 88SX50XX/88SX60XX/88SX70XX/SoC SATA
+device		siis			# SiliconImage SiI3124/SiI3132/SiI3531 SATA
+
+# SCSI Controllers
+device		ahc			# AHA2940 and onboard AIC7xxx devices
+options 	AHC_REG_PRETTY_PRINT	# Print register bitfields in debug
+					# output.  Adds ~128k to driver.
+device		ahd			# AHA39320/29320 and onboard AIC79xx devices
+options 	AHD_REG_PRETTY_PRINT	# Print register bitfields in debug
+					# output.  Adds ~215k to driver.
+device		esp			# AMD Am53C974 (Tekram DC-390(T))
+device		hptiop			# Highpoint RocketRaid 3xxx series
+device		isp			# Qlogic family
+#device		ispfw			# Firmware for QLogic HBAs- normally a module
+device		mpt			# LSI-Logic MPT-Fusion
+device		mps			# LSI-Logic MPT-Fusion 2
+device		mpr			# LSI-Logic MPT-Fusion 3
+#device		ncr			# NCR/Symbios Logic
+device		sym			# NCR/Symbios Logic (newer chipsets + those of `ncr')
+device		trm			# Tekram DC395U/UW/F DC315U adapters
+
+device		adv			# Advansys SCSI adapters
+device		adw			# Advansys wide SCSI adapters
+device		aic			# Adaptec 15[012]x SCSI adapters, AIC-6[23]60.
+device		bt			# Buslogic/Mylex MultiMaster SCSI adapters
+device		isci			# Intel C600 SAS controller
+
+# ATA/SCSI peripherals
+device		scbus			# SCSI bus (required for ATA/SCSI)
+device		ch			# SCSI media changers
+device		da			# Direct Access (disks)
+device		sa			# Sequential Access (tape etc)
+device		cd			# CD
+device		pass			# Passthrough device (direct ATA/SCSI access)
+device		ses			# Enclosure Services (SES and SAF-TE)
+#device		ctl			# CAM Target Layer
+
+# RAID controllers interfaced to the SCSI subsystem
+device		amr			# AMI MegaRAID
+device		arcmsr			# Areca SATA II RAID
+device		ciss			# Compaq Smart RAID 5*
+device		dpt			# DPT Smartcache III, IV - See NOTES for options
+device		hptmv			# Highpoint RocketRAID 182x
+device		hptnr			# Highpoint DC7280, R750
+device		hptrr			# Highpoint RocketRAID 17xx, 22xx, 23xx, 25xx
+device		hpt27xx			# Highpoint RocketRAID 27xx
+device		iir			# Intel Integrated RAID
+device		ips			# IBM (Adaptec) ServeRAID
+device		mly			# Mylex AcceleRAID/eXtremeRAID
+device		twa			# 3ware 9000 series PATA/SATA RAID
+device		tws			# LSI 3ware 9750 SATA+SAS 6Gb/s RAID controller
+
+# RAID controllers
+device		aac			# Adaptec FSA RAID
+device		aacp			# SCSI passthrough for aac (requires CAM)
+device		aacraid			# Adaptec by PMC RAID
+device		ida			# Compaq Smart RAID
+device		mfi			# LSI MegaRAID SAS
+device		mlx			# Mylex DAC960 family
+device		mrsas			# LSI/Avago MegaRAID SAS/SATA, 6Gb/s and 12Gb/s
+device		pmspcv			# PMC-Sierra SAS/SATA Controller driver
+#XXX pointer/int warnings
+#device		pst			# Promise Supertrak SX6000
+device		twe			# 3ware ATA RAID
+
+# NVM Express (NVMe) support
+device		nvme			# base NVMe driver
+device		nvd			# expose NVMe namespaces as disks, depends on nvme
+
+# atkbdc0 controls both the keyboard and the PS/2 mouse
+device		atkbdc			# AT keyboard controller
+device		atkbd			# AT keyboard
+device		psm			# PS/2 mouse
+
+device		kbdmux			# keyboard multiplexer
+
+device		vga			# VGA video card driver
+options 	VESA			# Add support for VESA BIOS Extensions (VBE)
+
+device		splash			# Splash screen and screen saver support
+
+# syscons is the default console driver, resembling an SCO console
+device		sc
+options 	SC_PIXEL_MODE		# add support for the raster text mode
+
+# vt is the new video console driver
+device		vt
+device		vt_vga
+device		vt_efifb
+
+device		agp			# support several AGP chipsets
+
+# PCCARD (PCMCIA) support
+# PCMCIA and cardbus bridge support
+device		cbb			# cardbus (yenta) bridge
+device		pccard			# PC Card (16-bit) bus
+device		cardbus			# CardBus (32-bit) bus
+
+# Serial (COM) ports
+device		uart			# Generic UART driver
+
+# Parallel port
+device		ppc
+device		ppbus			# Parallel port bus (required)
+device		lpt			# Printer
+device		ppi			# Parallel port interface device
+#device		vpo			# Requires scbus and da
+
+device		puc			# Multi I/O cards and multi-channel UARTs
+
+# PCI Ethernet NICs.
+device		de			# DEC/Intel DC21x4x (``Tulip'')
+device		em			# Intel PRO/1000 Gigabit Ethernet Family
+device		igb			# Intel PRO/1000 PCIE Server Gigabit Family
+device		ix			# Intel PRO/10GbE PCIE PF Ethernet
+device		ixv			# Intel PRO/10GbE PCIE VF Ethernet
+device		ixl			# Intel XL710 40Gbe PCIE Ethernet
+device		ixlv			# Intel XL710 40Gbe VF PCIE Ethernet
+device		le			# AMD Am7900 LANCE and Am79C9xx PCnet
+device		ti			# Alteon Networks Tigon I/II gigabit Ethernet
+device		txp			# 3Com 3cR990 (``Typhoon'')
+device		vx			# 3Com 3c590, 3c595 (``Vortex'')
+
+# PCI Ethernet NICs that use the common MII bus controller code.
+# NOTE: Be sure to keep the 'device miibus' line in order to use these NICs!
+device		miibus			# MII bus support
+device		ae			# Attansic/Atheros L2 FastEthernet
+device		age			# Attansic/Atheros L1 Gigabit Ethernet
+device		alc			# Atheros AR8131/AR8132 Ethernet
+device		ale			# Atheros AR8121/AR8113/AR8114 Ethernet
+device		bce			# Broadcom BCM5706/BCM5708 Gigabit Ethernet
+device		bfe			# Broadcom BCM440x 10/100 Ethernet
+device		bge			# Broadcom BCM570xx Gigabit Ethernet
+device		cas			# Sun Cassini/Cassini+ and NS DP83065 Saturn
+device		dc			# DEC/Intel 21143 and various workalikes
+device		et			# Agere ET1310 10/100/Gigabit Ethernet
+device		fxp			# Intel EtherExpress PRO/100B (82557, 82558)
+device		gem			# Sun GEM/Sun ERI/Apple GMAC
+device		hme			# Sun HME (Happy Meal Ethernet)
+device		jme			# JMicron JMC250 Gigabit/JMC260 Fast Ethernet
+device		lge			# Level 1 LXT1001 gigabit Ethernet
+device		msk			# Marvell/SysKonnect Yukon II Gigabit Ethernet
+device		nfe			# nVidia nForce MCP on-board Ethernet
+device		nge			# NatSemi DP83820 gigabit Ethernet
+device		pcn			# AMD Am79C97x PCI 10/100 (precedence over 'le')
+device		re			# RealTek 8139C+/8169/8169S/8110S
+device		rl			# RealTek 8129/8139
+device		sf			# Adaptec AIC-6915 (``Starfire'')
+device		sge			# Silicon Integrated Systems SiS190/191
+device		sis			# Silicon Integrated Systems SiS 900/SiS 7016
+device		sk			# SysKonnect SK-984x & SK-982x gigabit Ethernet
+device		ste			# Sundance ST201 (D-Link DFE-550TX)
+device		stge			# Sundance/Tamarack TC9021 gigabit Ethernet
+device		tl			# Texas Instruments ThunderLAN
+device		tx			# SMC EtherPower II (83c170 ``EPIC'')
+device		vge			# VIA VT612x gigabit Ethernet
+device		vr			# VIA Rhine, Rhine II
+device		wb			# Winbond W89C840F
+device		xl			# 3Com 3c90x (``Boomerang'', ``Cyclone'')
+
+# Wireless NIC cards
+device		wlan			# 802.11 support
+options 	IEEE80211_DEBUG		# enable debug msgs
+options 	IEEE80211_AMPDU_AGE	# age frames in AMPDU reorder q's
+options 	IEEE80211_SUPPORT_MESH	# enable 802.11s draft support
+device		wlan_wep		# 802.11 WEP support
+device		wlan_ccmp		# 802.11 CCMP support
+device		wlan_tkip		# 802.11 TKIP support
+device		wlan_amrr		# AMRR transmit rate control algorithm
+device		an			# Aironet 4500/4800 802.11 wireless NICs.
+device		ath			# Atheros NICs
+device		ath_pci			# Atheros pci/cardbus glue
+device		ath_hal			# pci/cardbus chip support
+options 	AH_SUPPORT_AR5416	# enable AR5416 tx/rx descriptors
+options 	AH_AR5416_INTERRUPT_MITIGATION # AR5416 interrupt mitigation
+options 	ATH_ENABLE_11N		# Enable 802.11n support for AR5416 and later
+device		ath_rate_sample		# SampleRate tx rate control for ath
+#device		bwi			# Broadcom BCM430x/BCM431x wireless NICs.
+#device		bwn			# Broadcom BCM43xx wireless NICs.
+device		ipw			# Intel 2100 wireless NICs.
+device		iwi			# Intel 2200BG/2225BG/2915ABG wireless NICs.
+device		iwn			# Intel 4965/1000/5000/6000 wireless NICs.
+device		malo			# Marvell Libertas wireless NICs.
+device		mwl			# Marvell 88W8363 802.11n wireless NICs.
+device		ral			# Ralink Technology RT2500 wireless NICs.
+device		wi			# WaveLAN/Intersil/Symbol 802.11 wireless NICs.
+device		wpi			# Intel 3945ABG wireless NICs.
+
+# Pseudo devices.
+device		loop			# Network loopback
+device		random			# Entropy device
+device		padlock_rng		# VIA Padlock RNG
+device		rdrand_rng		# Intel Bull Mountain RNG
+device		ether			# Ethernet support
+device		vlan			# 802.1Q VLAN support
+device		tun			# Packet tunnel.
+device		md			# Memory "disks"
+device		gif			# IPv6 and IPv4 tunneling
+device		firmware		# firmware assist module
+
+# The `bpf' device enables the Berkeley Packet Filter.
+# Be aware of the administrative consequences of enabling this!
+# Note that 'bpf' is required for DHCP.
+device		bpf			# Berkeley packet filter
+
+# USB support
+options 	USB_DEBUG		# enable debug msgs
+device		uhci			# UHCI PCI->USB interface
+device		ohci			# OHCI PCI->USB interface
+device		ehci			# EHCI PCI->USB interface (USB 2.0)
+device		xhci			# XHCI PCI->USB interface (USB 3.0)
+device		usb			# USB Bus (required)
+device		ukbd			# Keyboard
+device		umass			# Disks/Mass storage - Requires scbus and da
+
+# Sound support
+device		sound			# Generic sound driver (required)
+device		snd_cmi			# CMedia CMI8338/CMI8738
+device		snd_csa			# Crystal Semiconductor CS461x/428x
+device		snd_emu10kx		# Creative SoundBlaster Live! and Audigy
+device		snd_es137x		# Ensoniq AudioPCI ES137x
+device		snd_hda			# Intel High Definition Audio
+device		snd_ich			# Intel, NVidia and other ICH AC'97 Audio
+device		snd_via8233		# VIA VT8233x Audio
+
+# MMC/SD
+device		mmc			# MMC/SD bus
+device		mmcsd			# MMC/SD memory card
+device		sdhci			# Generic PCI SD Host Controller
+
+# VirtIO support
+device		virtio			# Generic VirtIO bus (required)
+device		virtio_pci		# VirtIO PCI device
+device		vtnet			# VirtIO Ethernet device
+device		virtio_blk		# VirtIO Block device
+device		virtio_scsi		# VirtIO SCSI device
+device		virtio_balloon		# VirtIO Memory Balloon device
+
+# HyperV drivers and enhancement support
+device		hyperv			# HyperV drivers 
+
+# Xen HVM Guest Optimizations
+# NOTE: XENHVM depends on xenpci.  They must be added or removed together.
+options 	XENHVM			# Xen HVM kernel infrastructure
+device		xenpci			# Xen HVM Hypervisor services driver
+
+# VMware support
+device		vmx			# VMware VMXNET3 Ethernet
+
+# Netmap provides direct access to TX/RX rings on supported NICs
+device		netmap			# netmap(4) support
+
+# The crypto framework is required by IPSEC
+device		crypto			# Required by IPSEC
+
+options		SW_WATCHDOG

--- a/sys/amd64/conf/EVDEV
+++ b/sys/amd64/conf/EVDEV
@@ -1,5 +1,5 @@
 #
-# GENERIC -- Generic kernel configuration file for FreeBSD/amd64
+# EVDEV -- Kernel configuration file for EVDEV enabled FreeBSD/amd64
 #
 # For more information on this file, please read the config(5) manual page,
 # and/or the handbook section on Kernel Configuration Files:
@@ -19,7 +19,7 @@
 # $FreeBSD$
 
 cpu		HAMMER
-ident		GENERIC
+ident		EVDEV
 
 makeoptions	DEBUG=-g		# Build kernel with gdb(1) debug symbols
 makeoptions	WITH_CTF=1		# Run ctfconvert(1) for DTrace support
@@ -87,10 +87,7 @@ options 	GDB			# Support remote GDB.
 options 	DEADLKRES		# Enable the deadlock resolver
 options 	INVARIANTS		# Enable calls of extra sanity checking
 options 	INVARIANT_SUPPORT	# Extra sanity checks of internal structures, required by INVARIANTS
-#options		DEBUG_MEMGUARD
-#options		DEBUG_REDZONE
 options 	WITNESS			# Enable checks to detect deadlocks and cycles
-options		WITNESS_ALL
 options 	WITNESS_SKIPSPIN	# Don't run witness on spinlocks for speed
 options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
 
@@ -98,6 +95,7 @@ options 	MALLOC_DEBUG_MAXZONES=8	# Separate malloc(9) zones
 options 	SMP			# Symmetric MultiProcessor Kernel
 options 	DEVICE_NUMA		# I/O Device Affinity
 
+# Create /dev/input/eventX for input devices
 options		EVDEV
 
 # CPU frequency control
@@ -227,6 +225,7 @@ device		ppi			# Parallel port interface device
 device		puc			# Multi I/O cards and multi-channel UARTs
 
 # PCI Ethernet NICs.
+device		bxe			# Broadcom NetXtreme II BCM5771X/BCM578XX 10GbE
 device		de			# DEC/Intel DC21x4x (``Tulip'')
 device		em			# Intel PRO/1000 Gigabit Ethernet Family
 device		igb			# Intel PRO/1000 PCIE Server Gigabit Family
@@ -355,7 +354,7 @@ device		virtio_scsi		# VirtIO SCSI device
 device		virtio_balloon		# VirtIO Memory Balloon device
 
 # HyperV drivers and enhancement support
-device		hyperv			# HyperV drivers 
+device		hyperv			# HyperV drivers
 
 # Xen HVM Guest Optimizations
 # NOTE: XENHVM depends on xenpci.  They must be added or removed together.
@@ -370,5 +369,3 @@ device		netmap			# netmap(4) support
 
 # The crypto framework is required by IPSEC
 device		crypto			# Required by IPSEC
-
-options		SW_WATCHDOG

--- a/sys/amd64/conf/EVDEV-NODEBUG
+++ b/sys/amd64/conf/EVDEV-NODEBUG
@@ -1,0 +1,40 @@
+#
+# EVDEV-NODEBUG -- WITNESS and INVARIANTS free kernel configuration file 
+#		     for FreeBSD/amd64
+#
+# This configuration file removes several debugging options, including
+# WITNESS and INVARIANTS checking, which are known to have significant
+# performance impact on running systems.  When benchmarking new features
+# this kernel should be used instead of the standard GENERIC.
+# This kernel configuration should never appear outside of the HEAD
+# of the FreeBSD tree.
+#
+# For more information on this file, please read the config(5) manual page,
+# and/or the handbook section on Kernel Configuration Files:
+#
+#    http://www.FreeBSD.org/doc/en_US.ISO8859-1/books/handbook/kernelconfig-config.html
+#
+# The handbook is also available locally in /usr/share/doc/handbook
+# if you've installed the doc distribution, otherwise always see the
+# FreeBSD World Wide Web server (http://www.FreeBSD.org/) for the
+# latest information.
+#
+# An exhaustive list of options and more detailed explanations of the
+# device lines is also present in the ../../conf/NOTES and NOTES files.
+# If you are in doubt as to the purpose or necessity of a line, check first
+# in NOTES.
+#
+# $FreeBSD$
+
+include GENERIC
+
+ident   GENERIC-NODEBUG
+
+nooptions       INVARIANTS
+nooptions       INVARIANT_SUPPORT
+nooptions       WITNESS
+nooptions       WITNESS_SKIPSPIN
+nooptions       DEADLKRES
+
+# Create /dev/input/eventX input devices for libinput and Wayland
+options		EVDEV

--- a/sys/amd64/conf/EVDEV-NODEBUG
+++ b/sys/amd64/conf/EVDEV-NODEBUG
@@ -1,5 +1,5 @@
 #
-# EVDEV-NODEBUG -- WITNESS and INVARIANTS free kernel configuration file 
+# EVDEV-NODEBUG -- WITNESS and INVARIANTS free kernel configuration file
 #		     for FreeBSD/amd64
 #
 # This configuration file removes several debugging options, including
@@ -26,15 +26,12 @@
 #
 # $FreeBSD$
 
-include GENERIC
+include EVDEV
 
-ident   GENERIC-NODEBUG
+ident   EVDEV-NODEBUG
 
 nooptions       INVARIANTS
 nooptions       INVARIANT_SUPPORT
 nooptions       WITNESS
 nooptions       WITNESS_SKIPSPIN
 nooptions       DEADLKRES
-
-# Create /dev/input/eventX input devices for libinput and Wayland
-options		EVDEV

--- a/sys/conf/files
+++ b/sys/conf/files
@@ -1481,6 +1481,11 @@ dev/etherswitch/ip17x/ip17x_vlans.c	optional ip17x
 dev/etherswitch/miiproxy.c		optional miiproxy
 dev/etherswitch/rtl8366/rtl8366rb.c	optional rtl8366rb
 dev/etherswitch/ukswitch/ukswitch.c	optional ukswitch
+dev/evdev/evdev.c			optional evdev
+dev/evdev/cdev.c			optional evdev
+dev/evdev/evdev_mt.c			optional evdev
+dev/evdev/evdev_utils.c			optional evdev
+dev/evdev/uinput.c			optional evdev
 dev/ex/if_ex.c			optional ex
 dev/ex/if_ex_isa.c		optional ex isa
 dev/ex/if_ex_pccard.c		optional ex pccard

--- a/sys/conf/options
+++ b/sys/conf/options
@@ -985,3 +985,6 @@ BHND_LOGLEVEL	opt_global.h
 
 # GPIO and child devices
 GPIO_SPI_DEBUG	opt_gpio.h
+
+# evdev protocol support
+EVDEV		opt_evdev.h

--- a/sys/dev/evdev/cdev.c
+++ b/sys/dev/evdev/cdev.c
@@ -1,0 +1,835 @@
+/*-
+ * Copyright (c) 2014 Jakub Wojciech Klama <jceel@FreeBSD.org>
+ * Copyright (c) 2015-2016 Vladimir Kondratyev <wulf@cicgroup.ru>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#include <sys/types.h>
+#include <sys/bitstring.h>
+#include <sys/systm.h>
+#include <sys/param.h>
+#include <sys/kernel.h>
+#include <sys/conf.h>
+#include <sys/uio.h>
+#include <sys/proc.h>
+#include <sys/poll.h>
+#include <sys/filio.h>
+#include <sys/fcntl.h>
+#include <sys/selinfo.h>
+#include <sys/malloc.h>
+#include <sys/time.h>
+
+#include <dev/evdev/input.h>
+#include <dev/evdev/evdev.h>
+
+#undef	DEBUG
+#ifdef DEBUG
+#define	debugf(fmt, args...)	printf("evdev: " fmt "\n", ##args);
+#else
+#define	debugf(fmt, args...)
+#endif
+
+#define	DEF_RING_REPORTS	8
+
+static d_open_t		evdev_open;
+static d_read_t		evdev_read;
+static d_write_t	evdev_write;
+static d_ioctl_t	evdev_ioctl;
+static d_poll_t		evdev_poll;
+static d_kqfilter_t	evdev_kqfilter;
+
+static int evdev_kqread(struct knote *kn, long hint);
+static void evdev_kqdetach(struct knote *kn);
+static void evdev_dtor(void *);
+static int evdev_ioctl_eviocgbit(struct evdev_dev *, int, int, caddr_t);
+static void evdev_client_filter_queue(struct evdev_client *, uint16_t);
+
+static struct cdevsw evdev_cdevsw = {
+	.d_version = D_VERSION,
+	.d_open = evdev_open,
+	.d_read = evdev_read,
+	.d_write = evdev_write,
+	.d_ioctl = evdev_ioctl,
+	.d_poll = evdev_poll,
+	.d_kqfilter = evdev_kqfilter,
+	.d_name = "evdev",
+};
+
+static struct filterops evdev_cdev_filterops = {
+	.f_isfd = 1,
+	.f_attach = NULL,
+	.f_detach = evdev_kqdetach,
+	.f_event = evdev_kqread,
+};
+
+static int
+evdev_open(struct cdev *dev, int oflags, int devtype, struct thread *td)
+{
+	struct evdev_dev *evdev = dev->si_drv1;
+	struct evdev_client *client;
+	size_t buffer_size;
+	int ret;
+
+	if (evdev == NULL)
+		return (ENODEV);
+
+	/* Initialize client structure */
+	buffer_size = evdev->ev_report_size * DEF_RING_REPORTS;
+	client = malloc(offsetof(struct evdev_client, ec_buffer) +
+	    sizeof(struct input_event) * buffer_size,
+	    M_EVDEV, M_WAITOK | M_ZERO);
+
+	/* Initialize ring buffer */
+	client->ec_buffer_size = buffer_size;
+	client->ec_buffer_head = 0;
+	client->ec_buffer_tail = 0;
+	client->ec_buffer_ready = 0;
+
+	client->ec_evdev = evdev;
+	/* Avoid race with evdev_unregister */
+	EVDEV_LOCK(evdev);
+	if (dev->si_drv1 == NULL)
+		ret = ENODEV;
+	else
+		ret = evdev_register_client(evdev, client);
+	EVDEV_UNLOCK(evdev);
+	if (ret != 0) {
+		debugf("cdev: cannot register evdev client");
+		free(client, M_EVDEV);
+		return (ret);
+	}
+
+	mtx_init(&client->ec_buffer_mtx, "evclient", "evdev", MTX_DEF);
+	knlist_init_mtx(&client->ec_selp.si_note, &client->ec_buffer_mtx);
+
+	ret = devfs_set_cdevpriv(client, evdev_dtor);
+	if (ret != 0)
+		evdev_dtor(client);
+
+	return (ret);
+}
+
+static void
+evdev_dtor(void *data)
+{
+	struct evdev_client *client = (struct evdev_client *)data;
+
+	knlist_clear(&client->ec_selp.si_note, 0);
+	seldrain(&client->ec_selp);
+	knlist_destroy(&client->ec_selp.si_note);
+	funsetown(&client->ec_sigio);
+	EVDEV_LOCK(client->ec_evdev);
+	if (!client->ec_revoked)
+		evdev_dispose_client(client->ec_evdev, client);
+	EVDEV_UNLOCK(client->ec_evdev);
+	mtx_destroy(&client->ec_buffer_mtx);
+	free(client, M_EVDEV);
+}
+
+static int
+evdev_read(struct cdev *dev, struct uio *uio, int ioflag)
+{
+	struct evdev_dev *evdev = dev->si_drv1;
+	struct evdev_client *client;
+	struct input_event *event;
+	int ret = 0;
+	int remaining;
+
+	debugf("cdev: read %zd bytes by thread %d", uio->uio_resid,
+	    uio->uio_td->td_tid);
+
+	ret = devfs_get_cdevpriv((void **)&client);
+	if (ret != 0)
+		return (ret);
+
+	if (client->ec_revoked || evdev == NULL)
+		return (ENODEV);
+
+	/* Zero-sized reads are allowed for error checking */
+	if (uio->uio_resid != 0 && uio->uio_resid < sizeof(struct input_event))
+		return (EINVAL);
+
+	remaining = uio->uio_resid / sizeof(struct input_event);
+
+	EVDEV_CLIENT_LOCKQ(client);
+
+	if (EVDEV_CLIENT_EMPTYQ(client)) {
+		if (ioflag & O_NONBLOCK)
+			ret = EWOULDBLOCK;
+		else {
+			if (remaining != 0) {
+				client->ec_blocked = true;
+				ret = mtx_sleep(client, &client->ec_buffer_mtx,
+				    PCATCH, "evread", 0);
+			}
+		}
+	}
+
+	while (ret == 0 && !EVDEV_CLIENT_EMPTYQ(client) && remaining > 0) {
+		event = &client->ec_buffer[client->ec_buffer_head];
+		client->ec_buffer_head =
+		    (client->ec_buffer_head + 1) % client->ec_buffer_size;
+		remaining--;
+
+		EVDEV_CLIENT_UNLOCKQ(client);
+		ret = uiomove(event, sizeof(struct input_event), uio);
+		EVDEV_CLIENT_LOCKQ(client);
+	}
+
+	EVDEV_CLIENT_UNLOCKQ(client);
+
+	return (ret);
+}
+
+static int
+evdev_write(struct cdev *dev, struct uio *uio, int ioflag)
+{
+	struct evdev_dev *evdev = dev->si_drv1;
+	struct evdev_client *client;
+	struct input_event event;
+	int ret = 0;
+
+	debugf("cdev: write %zd bytes by thread %d", uio->uio_resid,
+	    uio->uio_td->td_tid);
+
+	ret = devfs_get_cdevpriv((void **)&client);
+	if (ret != 0)
+		return (ret);
+
+	if (client->ec_revoked || evdev == NULL)
+		return (ENODEV);
+
+	if (uio->uio_resid % sizeof(struct input_event) != 0) {
+		debugf("write size not multiple of struct input_event size");
+		return (EINVAL);
+	}
+
+	while (uio->uio_resid > 0 && ret == 0) {
+		ret = uiomove(&event, sizeof(struct input_event), uio);
+		if (ret == 0)
+			ret = evdev_inject_event(evdev, event.type, event.code,
+			    event.value);
+	}
+
+	return (ret);
+}
+
+static int
+evdev_poll(struct cdev *dev, int events, struct thread *td)
+{
+	struct evdev_dev *evdev = dev->si_drv1;
+	struct evdev_client *client;
+	int ret;
+	int revents = 0;
+
+	debugf("cdev: poll by thread %d", td->td_tid);
+
+	ret = devfs_get_cdevpriv((void **)&client);
+	if (ret != 0)
+		return (POLLNVAL);
+
+	if (client->ec_revoked || evdev == NULL)
+		return (POLLNVAL);
+
+	if (events & (POLLIN | POLLRDNORM)) {
+		EVDEV_CLIENT_LOCKQ(client);
+		if (!EVDEV_CLIENT_EMPTYQ(client))
+			revents = events & (POLLIN | POLLRDNORM);
+		else {
+			client->ec_selected = true;
+			selrecord(td, &client->ec_selp);
+		}
+		EVDEV_CLIENT_UNLOCKQ(client);
+	}
+
+	return (revents);
+}
+
+static int
+evdev_kqfilter(struct cdev *dev, struct knote *kn)
+{
+	struct evdev_dev *evdev = dev->si_drv1;
+	struct evdev_client *client;
+	int ret;
+
+	ret = devfs_get_cdevpriv((void **)&client);
+	if (ret != 0)
+		return (ret);
+
+	if (client->ec_revoked || evdev == NULL)
+		return (ENODEV);
+
+	switch(kn->kn_filter) {
+	case EVFILT_READ:
+		kn->kn_fop = &evdev_cdev_filterops;
+		break;
+	default:
+		return(EINVAL);
+	}
+	kn->kn_hook = (caddr_t)client;
+
+	knlist_add(&client->ec_selp.si_note, kn, 0);
+	return (0);
+}
+
+static int
+evdev_kqread(struct knote *kn, long hint)
+{
+	struct evdev_client *client;
+	int ret;
+
+	client = (struct evdev_client *)kn->kn_hook;
+
+	EVDEV_CLIENT_LOCKQ_ASSERT(client);
+
+	kn->kn_data = EVDEV_CLIENT_SIZEQ(client) * sizeof(struct input_event);
+	ret = !EVDEV_CLIENT_EMPTYQ(client);
+	return (ret);
+}
+
+static void
+evdev_kqdetach(struct knote *kn)
+{
+	struct evdev_client *client;
+
+	client = (struct evdev_client *)kn->kn_hook;
+	knlist_remove(&client->ec_selp.si_note, kn, 0);
+}
+
+static int
+evdev_ioctl(struct cdev *dev, u_long cmd, caddr_t data, int fflag,
+    struct thread *td)
+{
+	struct evdev_dev *evdev = dev->si_drv1;
+	struct evdev_client *client;
+	struct input_keymap_entry *ke;
+	int ret, len, limit, type_num;
+	uint32_t code;
+	size_t nvalues;
+
+	ret = devfs_get_cdevpriv((void **)&client);
+	if (ret != 0)
+		return (ret);
+
+	if (client->ec_revoked || evdev == NULL)
+		return (ENODEV);
+
+	/* file I/O ioctl handling */
+	switch (cmd) {
+	case FIOSETOWN:
+		return (fsetown(*(int *)data, &client->ec_sigio));
+
+	case FIOGETOWN:
+		*(int *)data = fgetown(&client->ec_sigio);
+		return (0);
+
+	case FIONBIO:
+		return (0);
+
+	case FIOASYNC:
+		if (*(int *)data)
+			client->ec_async = true;
+		else
+			client->ec_async = false;
+
+		return (0);
+
+	case FIONREAD:
+		EVDEV_CLIENT_LOCKQ(client);
+		*(int *)data =
+		    EVDEV_CLIENT_SIZEQ(client) * sizeof(struct input_event);
+		EVDEV_CLIENT_UNLOCKQ(client);
+		return (0);
+	}
+
+	len = IOCPARM_LEN(cmd);
+	debugf("cdev: ioctl called: cmd=0x%08lx, data=%p", cmd, data);
+
+	/* evdev fixed-length ioctls handling */
+	switch (cmd) {
+	case EVIOCGVERSION:
+		*(int *)data = EV_VERSION;
+		return (0);
+
+	case EVIOCGID:
+		debugf("cdev: EVIOCGID: bus=%d vendor=0x%04x product=0x%04x",
+		    evdev->ev_id.bustype, evdev->ev_id.vendor,
+		    evdev->ev_id.product);
+		memcpy(data, &evdev->ev_id, sizeof(struct input_id));
+		return (0);
+
+	case EVIOCGREP:
+		if (!evdev_event_supported(evdev, EV_REP))
+			return (ENOTSUP);
+
+		memcpy(data, evdev->ev_rep, sizeof(evdev->ev_rep));
+		return (0);
+
+	case EVIOCSREP:
+		if (!evdev_event_supported(evdev, EV_REP))
+			return (ENOTSUP);
+
+		evdev_inject_event(evdev, EV_REP, REP_DELAY, ((int *)data)[0]);
+		evdev_inject_event(evdev, EV_REP, REP_PERIOD,
+		    ((int *)data)[1]);
+		return (0);
+
+	case EVIOCGKEYCODE:
+		/* Fake unsupported ioctl */
+		return (0);
+
+	case EVIOCGKEYCODE_V2:
+		if (evdev->ev_methods == NULL ||
+		    evdev->ev_methods->ev_get_keycode == NULL)
+			return (ENOTSUP);
+
+		ke = (struct input_keymap_entry *)data;
+		evdev->ev_methods->ev_get_keycode(evdev, evdev->ev_softc, ke);
+		return (0);
+
+	case EVIOCSKEYCODE:
+		/* Fake unsupported ioctl */
+		return (0);
+
+	case EVIOCSKEYCODE_V2:
+		if (evdev->ev_methods == NULL ||
+		    evdev->ev_methods->ev_set_keycode == NULL)
+			return (ENOTSUP);
+
+		ke = (struct input_keymap_entry *)data;
+		evdev->ev_methods->ev_set_keycode(evdev, evdev->ev_softc, ke);
+		return (0);
+
+	case EVIOCGABS(0) ... EVIOCGABS(ABS_MAX):
+		if (evdev->ev_absinfo == NULL)
+			return (EINVAL);
+
+		memcpy(data, &evdev->ev_absinfo[cmd - EVIOCGABS(0)],
+		    sizeof(struct input_absinfo));
+		return (0);
+
+	case EVIOCSABS(0) ... EVIOCSABS(ABS_MAX):
+		if (evdev->ev_absinfo == NULL)
+			return (EINVAL);
+
+		code = cmd - EVIOCSABS(0);
+		/* mt-slot number can not be changed */
+		if (code == ABS_MT_SLOT)
+			return (EINVAL);
+
+		EVDEV_LOCK(evdev);
+		evdev_set_absinfo(evdev, code, (struct input_absinfo *)data);
+		EVDEV_UNLOCK(evdev);
+		return (0);
+
+	case EVIOCSFF:
+	case EVIOCRMFF:
+	case EVIOCGEFFECTS:
+		/* Fake unsupported ioctls */
+		return (0);
+
+	case EVIOCGRAB:
+		EVDEV_LOCK(evdev);
+		if (*(int *)data)
+			ret = evdev_grab_client(evdev, client);
+		else
+			ret = evdev_release_client(evdev, client);
+		EVDEV_UNLOCK(evdev);
+		return (ret);
+
+	case EVIOCREVOKE:
+		if (*(int *)data != 0)
+			return (EINVAL);
+
+		EVDEV_LOCK(evdev);
+		if (dev->si_drv1 != NULL && !client->ec_revoked)
+			evdev_dispose_client(evdev, client);
+		client->ec_revoked = true;
+		EVDEV_UNLOCK(evdev);
+		return (0);
+
+	case EVIOCSCLOCKID:
+		switch (*(int *)data) {
+		case CLOCK_REALTIME:
+			client->ec_clock_id = EV_CLOCK_REALTIME;
+			return (0);
+		case CLOCK_MONOTONIC:
+			client->ec_clock_id = EV_CLOCK_MONOTONIC;
+			return (0);
+		default:
+			return (EINVAL);
+		}
+	}
+
+	/* evdev variable-length ioctls handling */
+	switch (IOCBASECMD(cmd)) {
+	case EVIOCGNAME(0):
+		strlcpy(data, evdev->ev_name, len);
+		return (0);
+
+	case EVIOCGPHYS(0):
+		if (evdev->ev_dev == NULL && evdev->ev_shortname[0] == 0)
+			return (ENOENT);
+
+		strlcpy(data, evdev->ev_shortname, len);
+		return (0);
+
+	case EVIOCGUNIQ(0):
+		if (evdev->ev_dev == NULL && evdev->ev_serial[0] == 0)
+			return (ENOENT);
+
+		strlcpy(data, evdev->ev_serial, len);
+		return (0);
+
+	case EVIOCGPROP(0):
+		limit = MIN(len, bitstr_size(INPUT_PROP_CNT));
+		memcpy(data, evdev->ev_prop_flags, limit);
+		return (0);
+
+	case EVIOCGMTSLOTS(0):
+		if (evdev->ev_mt == NULL)
+			return (EINVAL);
+		if (len < sizeof(uint32_t))
+			return (EINVAL);
+		code = *(uint32_t *)data;
+		if (!ABS_IS_MT(code))
+			return (EINVAL);
+
+		nvalues =
+		    MIN(len / sizeof(int32_t) - 1, MAXIMAL_MT_SLOT(evdev) + 1);
+		for (int i = 0; i < nvalues; i++)
+			((int32_t *)data)[i + 1] =
+			    evdev_get_mt_value(evdev, i, code);
+		return (0);
+
+	case EVIOCGKEY(0):
+		limit = MIN(len, bitstr_size(KEY_CNT));
+		EVDEV_LOCK(evdev);
+		evdev_client_filter_queue(client, EV_KEY);
+		memcpy(data, evdev->ev_key_states, limit);
+		EVDEV_UNLOCK(evdev);
+		return (0);
+
+	case EVIOCGLED(0):
+		limit = MIN(len, bitstr_size(LED_CNT));
+		EVDEV_LOCK(evdev);
+		evdev_client_filter_queue(client, EV_LED);
+		memcpy(data, evdev->ev_led_states, limit);
+		EVDEV_UNLOCK(evdev);
+		return (0);
+
+	case EVIOCGSND(0):
+		limit = MIN(len, bitstr_size(SND_CNT));
+		EVDEV_LOCK(evdev);
+		evdev_client_filter_queue(client, EV_SND);
+		memcpy(data, evdev->ev_snd_states, limit);
+		EVDEV_UNLOCK(evdev);
+		return (0);
+
+	case EVIOCGSW(0):
+		limit = MIN(len, bitstr_size(SW_CNT));
+		EVDEV_LOCK(evdev);
+		evdev_client_filter_queue(client, EV_SW);
+		memcpy(data, evdev->ev_sw_states, limit);
+		EVDEV_UNLOCK(evdev);
+		return (0);
+
+	case EVIOCGBIT(0, 0) ... EVIOCGBIT(EV_MAX, 0):
+		type_num = IOCBASECMD(cmd) - EVIOCGBIT(0, 0);
+		debugf("cdev: EVIOCGBIT(%d): data=%p, len=%d", type_num, data, len);
+		return (evdev_ioctl_eviocgbit(evdev, type_num, len, data));
+	}
+
+	return (EINVAL);
+}
+
+static int
+evdev_ioctl_eviocgbit(struct evdev_dev *evdev, int type, int len, caddr_t data)
+{
+	unsigned long *bitmap;
+	int limit;
+
+	switch (type) {
+	case 0:
+		bitmap = evdev->ev_type_flags;
+		limit = EV_CNT;
+		break;
+	case EV_KEY:
+		bitmap = evdev->ev_key_flags;
+		limit = KEY_CNT;
+		break;
+	case EV_REL:
+		bitmap = evdev->ev_rel_flags;
+		limit = REL_CNT;
+		break;
+	case EV_ABS:
+		bitmap = evdev->ev_abs_flags;
+		limit = ABS_CNT;
+		break;
+	case EV_MSC:
+		bitmap = evdev->ev_msc_flags;
+		limit = MSC_CNT;
+		break;
+	case EV_LED:
+		bitmap = evdev->ev_led_flags;
+		limit = LED_CNT;
+		break;
+	case EV_SND:
+		bitmap = evdev->ev_snd_flags;
+		limit = SND_CNT;
+		break;
+	case EV_SW:
+		bitmap = evdev->ev_sw_flags;
+		limit = SW_CNT;
+		break;
+	case EV_FF:
+		/*
+		 * We don't support EV_FF now, so let's
+		 * just fake it returning only zeros.
+		 */
+		bzero(data, len);
+		return (0);
+	default:
+		return (ENOTTY);
+	}
+
+	/*
+	 * Clear ioctl data buffer in case it's bigger than
+	 * bitmap size
+	 */
+	bzero(data, len);
+
+	limit = bitstr_size(limit);
+	len = MIN(limit, len);
+	memcpy(data, bitmap, len);
+	return (0);
+}
+
+void
+evdev_notify_event(struct evdev_client *client)
+{
+
+	if (client->ec_blocked) {
+		client->ec_blocked = false;
+		wakeup(client);
+	}
+	if (client->ec_selected) {
+		client->ec_selected = false;
+		selwakeup(&client->ec_selp);
+	}
+	KNOTE_LOCKED(&client->ec_selp.si_note, 0);
+
+	if (client->ec_async && client->ec_sigio != NULL)
+		pgsigio(&client->ec_sigio, SIGIO, 0);
+}
+
+int
+evdev_cdev_create(struct evdev_dev *evdev)
+{
+	struct make_dev_args mda;
+	int ret, unit = 0;
+
+	make_dev_args_init(&mda);
+	mda.mda_flags = MAKEDEV_WAITOK | MAKEDEV_CHECKNAME;
+	mda.mda_devsw = &evdev_cdevsw;
+	mda.mda_uid = UID_ROOT;
+	mda.mda_gid = GID_WHEEL;
+	mda.mda_mode = 0600;
+	mda.mda_si_drv1 = evdev;
+
+	/* Try to coexist with cuse-backed input/event devices */
+	while ((ret = make_dev_s(&mda, &evdev->ev_cdev, "input/event%d", unit))
+	    == EEXIST)
+		unit++;
+
+	if (ret == 0)
+		evdev->ev_unit = unit;
+
+	return (ret);
+}
+
+int
+evdev_cdev_destroy(struct evdev_dev *evdev)
+{
+
+	destroy_dev(evdev->ev_cdev);
+	return (0);
+}
+
+static void
+evdev_client_gettime(struct evdev_client *client, struct timeval *tv)
+{
+
+	switch (client->ec_clock_id) {
+	case EV_CLOCK_BOOTTIME:
+		/*
+		 * XXX: FreeBSD does not support true POSIX monotonic clock.
+		 *      So aliase EV_CLOCK_BOOTTIME to EV_CLOCK_MONOTONIC.
+		 */
+	case EV_CLOCK_MONOTONIC:
+		microuptime(tv);
+		break;
+
+	case EV_CLOCK_REALTIME:
+	default:
+		microtime(tv);
+		break;
+	}
+}
+
+void
+evdev_client_push(struct evdev_client *client, uint16_t type, uint16_t code,
+    int32_t value)
+{
+	struct timeval time;
+	size_t count, head, tail, ready;
+
+	EVDEV_CLIENT_LOCKQ_ASSERT(client);
+	head = client->ec_buffer_head;
+	tail = client->ec_buffer_tail;
+	ready = client->ec_buffer_ready;
+	count = client->ec_buffer_size;
+
+	/* If queue is full drop its content and place SYN_DROPPED event */
+	if ((tail + 1) % count == head) {
+		debugf("client %p: buffer overflow", client);
+
+		head = (tail + count - 1) % count;
+		client->ec_buffer[head] = (struct input_event) {
+			.type = EV_SYN,
+			.code = SYN_DROPPED,
+			.value = 0
+		};
+		/*
+		 * XXX: Here is a small race window from now till the end of
+		 *      report. The queue is empty but client has been already
+		 *      notified of data readyness. Can be fixed in two ways:
+		 * 1. Implement bulk insert so queue lock would not be dropped
+		 *    till the SYN_REPORT event.
+		 * 2. Insert SYN_REPORT just now and skip remaining events
+		 */
+		client->ec_buffer_head = head;
+		client->ec_buffer_ready = head;
+	}
+
+	client->ec_buffer[tail].type = type;
+	client->ec_buffer[tail].code = code;
+	client->ec_buffer[tail].value = value;
+	client->ec_buffer_tail = (tail + 1) % count;
+
+	/* Allow users to read events only after report has been completed */
+	if (type == EV_SYN && code == SYN_REPORT) {
+		evdev_client_gettime(client, &time);
+		for (; ready != client->ec_buffer_tail;
+		    ready = (ready + 1) % count)
+			client->ec_buffer[ready].time = time;
+		client->ec_buffer_ready = client->ec_buffer_tail;
+	}
+}
+
+void
+evdev_client_dumpqueue(struct evdev_client *client)
+{
+	struct input_event *event;
+	size_t i, head, tail, ready, size;
+
+	head = client->ec_buffer_head;
+	tail = client->ec_buffer_tail;
+	ready = client->ec_buffer_ready;
+	size = client->ec_buffer_size;
+
+	printf("evdev client: %p\n", client);
+	printf("event queue: head=%zu ready=%zu tail=%zu size=%zu\n",
+	    head, ready, tail, size);
+
+	printf("queue contents:\n");
+
+	for (i = 0; i < size; i++) {
+		event = &client->ec_buffer[i];
+		printf("%zu: ", i);
+
+		if (i < head || i > tail)
+			printf("unused\n");
+		else
+			printf("type=%d code=%d value=%d ", event->type,
+			    event->code, event->value);
+
+		if (i == head)
+			printf("<- head\n");
+		else if (i == tail)
+			printf("<- tail\n");
+		else if (i == ready)
+			printf("<- ready\n");
+		else
+			printf("\n");
+	}
+}
+
+static void
+evdev_client_filter_queue(struct evdev_client *client, uint16_t type)
+{
+	struct input_event *event;
+	size_t head, tail, count, i;
+	bool last_was_syn = false;
+
+	EVDEV_CLIENT_LOCKQ(client);
+
+	i = head = client->ec_buffer_head;
+	tail = client->ec_buffer_tail;
+	count = client->ec_buffer_size;
+	client->ec_buffer_ready = client->ec_buffer_tail;
+
+	while (i != client->ec_buffer_tail) {
+		event = &client->ec_buffer[i];
+		i = (i + 1) % count;
+
+		/* Skip event of given type */
+		if (event->type == type)
+			continue;
+
+		/* Remove empty SYN_REPORT events */
+		if (event->type == EV_SYN && event->code == SYN_REPORT) {
+			if (last_was_syn)
+				continue;
+			else
+				client->ec_buffer_ready = (tail + 1) % count;
+		}
+
+		/* Rewrite entry */
+		memcpy(&client->ec_buffer[tail], event,
+		    sizeof(struct input_event));
+
+		last_was_syn = (event->type == EV_SYN &&
+		    event->code == SYN_REPORT);
+
+		tail = (tail + 1) % count;
+	}
+
+	client->ec_buffer_head = i;
+	client->ec_buffer_tail = tail;
+
+	EVDEV_CLIENT_UNLOCKQ(client);
+}

--- a/sys/dev/evdev/evdev.c
+++ b/sys/dev/evdev/evdev.c
@@ -1,0 +1,977 @@
+/*-
+ * Copyright (c) 2014 Jakub Wojciech Klama <jceel@FreeBSD.org>
+ * Copyright (c) 2015-2016 Vladimir Kondratyev <wulf@cicgroup.ru>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/param.h>
+#include <sys/bus.h>
+#include <sys/kernel.h>
+#include <sys/conf.h>
+#include <sys/malloc.h>
+#include <sys/bitstring.h>
+
+#include <dev/pci/pcireg.h>
+#include <dev/pci/pcivar.h>
+#include <dev/usb/usb.h>
+#include <dev/usb/usbdi.h>
+
+#include <dev/evdev/input.h>
+#include <dev/evdev/evdev.h>
+
+#ifdef DEBUG
+#define	debugf(fmt, args...)	printf("evdev: " fmt "\n", ##args)
+#else
+#define	debugf(fmt, args...)
+#endif
+
+enum evdev_sparse_result
+{
+	EV_SKIP_EVENT,		/* Event value not changed */
+	EV_REPORT_EVENT,	/* Event value changed */
+	EV_REPORT_MT_SLOT,	/* Event value and MT slot number changed */
+};
+
+MALLOC_DEFINE(M_EVDEV, "evdev", "evdev memory");
+
+static void evdev_assign_id(struct evdev_dev *);
+static void evdev_start_repeat(struct evdev_dev *, uint16_t);
+static void evdev_stop_repeat(struct evdev_dev *);
+static int evdev_check_event(struct evdev_dev *, uint16_t, uint16_t, int32_t);
+
+static inline void
+bit_change(bitstr_t *bitstr, int bit, int value)
+{
+	if (value)
+		bit_set(bitstr, bit);
+	else
+		bit_clear(bitstr, bit);
+}
+
+struct evdev_dev *
+evdev_alloc(void)
+{
+
+	return malloc(sizeof(struct evdev_dev), M_EVDEV, M_WAITOK | M_ZERO);
+}
+
+void
+evdev_free(struct evdev_dev *evdev)
+{
+
+	free(evdev, M_EVDEV);
+}
+
+static struct input_absinfo *
+evdev_alloc_absinfo(void)
+{
+
+	return (malloc(sizeof(struct input_absinfo) * ABS_CNT, M_EVDEV,
+	    M_WAITOK | M_ZERO));
+}
+
+static void
+evdev_free_absinfo(struct input_absinfo *absinfo)
+{
+
+	free(absinfo, M_EVDEV);
+}
+
+int
+evdev_set_report_size(struct evdev_dev *evdev, size_t report_size)
+{
+	if (report_size > KEY_CNT + REL_CNT + ABS_CNT + MAX_MT_SLOTS * MT_CNT +
+	    MSC_CNT + LED_CNT + SND_CNT + SW_CNT + FF_CNT)
+		return (EINVAL);
+
+	evdev->ev_report_size = report_size;
+	return (0);
+}
+
+static size_t
+evdev_estimate_report_size(struct evdev_dev *evdev)
+{
+	size_t size = 0;
+	int res;
+
+	/*
+	 * Keyboards generate one event per report but other devices with
+	 * buttons like mouses can report events simultaneously
+	 */
+	bit_ffs_at(evdev->ev_key_flags, KEY_OK, KEY_CNT - KEY_OK, &res);
+	if (res == -1)
+		bit_ffs(evdev->ev_key_flags, BTN_MISC, &res);
+	size += (res != -1);
+	bit_count(evdev->ev_key_flags, BTN_MISC, KEY_OK - BTN_MISC, &res);
+	size += res;
+
+	/* All relative axes can be reported simultaneously */
+	bit_count(evdev->ev_rel_flags, 0, REL_CNT, &res);
+	size += res;
+
+	/*
+	 * All absolute axes can be reported simultaneously.
+	 * Multitouch axes can be reported ABS_MT_SLOT times
+	 */
+	if (evdev->ev_absinfo != NULL) {
+		bit_count(evdev->ev_abs_flags, 0, ABS_CNT, &res);
+		size += res;
+		bit_count(evdev->ev_abs_flags, ABS_MT_FIRST, MT_CNT, &res);
+		if (res > 0) {
+			res++;	/* ABS_MT_SLOT or SYN_MT_REPORT */
+			if (bit_test(evdev->ev_abs_flags, ABS_MT_SLOT))
+				/* MT type B */
+				size += res * MAXIMAL_MT_SLOT(evdev);
+			else
+				/* MT type A */
+				size += res * (MAX_MT_REPORTS - 1);
+		}
+	}
+
+	/* All misc events can be reported simultaneously */
+	bit_count(evdev->ev_msc_flags, 0, MSC_CNT, &res);
+	size += res;
+
+	/* All leds can be reported simultaneously */
+	bit_count(evdev->ev_led_flags, 0, LED_CNT, &res);
+	size += res;
+
+	/* Assume other events are generated once per report */
+	bit_ffs(evdev->ev_snd_flags, SND_CNT, &res);
+	size += (res != -1);
+
+	bit_ffs(evdev->ev_sw_flags, SW_CNT, &res);
+	size += (res != -1);
+
+	/* XXX: FF part is not implemented yet */
+
+	size++;		/* SYN_REPORT */
+	return (size);
+}
+
+int
+evdev_register(device_t dev, struct evdev_dev *evdev)
+{
+	int ret;
+
+	device_printf(dev, "registered evdev provider: %s <%s>\n",
+	    evdev->ev_name, evdev->ev_serial);
+
+	/* Initialize internal structures */
+	evdev->ev_dev = dev;
+	mtx_init(&evdev->ev_mtx, "evmtx", NULL, MTX_DEF);
+	LIST_INIT(&evdev->ev_clients);
+
+	if (dev != NULL)
+		strlcpy(evdev->ev_shortname, device_get_nameunit(dev), NAMELEN);
+
+	if (evdev_event_supported(evdev, EV_REP) &&
+	    bit_test(evdev->ev_flags, EVDEV_FLAG_SOFTREPEAT)) {
+		/* Initialize callout */
+		callout_init_mtx(&evdev->ev_rep_callout, &evdev->ev_mtx, 0);
+
+		if (evdev->ev_rep[REP_DELAY] == 0 &&
+		    evdev->ev_rep[REP_PERIOD] == 0) {
+			/* Supply default values */
+			evdev->ev_rep[REP_DELAY] = 250;
+			evdev->ev_rep[REP_PERIOD] = 33;
+		}
+	}
+
+	/* Retrieve bus info */
+	evdev_assign_id(evdev);
+
+	/* Initialize multitouch protocol type B states */
+	if (bit_test(evdev->ev_abs_flags, ABS_MT_SLOT) &&
+	    evdev->ev_absinfo != NULL && MAXIMAL_MT_SLOT(evdev) > 0)
+		evdev_mt_init(evdev);
+
+	/* Estimate maximum report size */
+	if (evdev->ev_report_size == 0) {
+		ret = evdev_set_report_size(evdev,
+		    evdev_estimate_report_size(evdev));
+		if (ret != 0)
+			goto bail_out;
+	}
+
+	/* Create char device node */
+	ret = evdev_cdev_create(evdev);
+bail_out:
+	if (ret != 0)
+		mtx_destroy(&evdev->ev_mtx);
+
+	return (ret);
+}
+
+int
+evdev_unregister(device_t dev, struct evdev_dev *evdev)
+{
+	struct evdev_client *client;
+	int ret;
+	device_printf(dev, "unregistered evdev provider: %s\n", evdev->ev_name);
+
+	EVDEV_LOCK(evdev);
+	evdev->ev_cdev->si_drv1 = NULL;
+	/* Wake up sleepers */
+	LIST_FOREACH(client, &evdev->ev_clients, ec_link) {
+		EVDEV_CLIENT_LOCKQ(client);
+		evdev_notify_event(client);
+		EVDEV_CLIENT_UNLOCKQ(client);
+	}
+	EVDEV_UNLOCK(evdev);
+
+	/* destroy_dev can sleep so release lock */
+	ret = evdev_cdev_destroy(evdev);
+	if (ret == 0)
+		mtx_destroy(&evdev->ev_mtx);
+
+	evdev_free_absinfo(evdev->ev_absinfo);
+	evdev_mt_free(evdev);
+
+	return (ret);
+}
+
+inline void
+evdev_set_name(struct evdev_dev *evdev, const char *name)
+{
+
+	snprintf(evdev->ev_name, NAMELEN, "%s", name);
+}
+
+inline void
+evdev_set_phys(struct evdev_dev *evdev, const char *name)
+{
+
+	snprintf(evdev->ev_shortname, NAMELEN, "%s", name);
+}
+
+inline void
+evdev_set_serial(struct evdev_dev *evdev, const char *serial)
+{
+
+	snprintf(evdev->ev_serial, NAMELEN, "%s", serial);
+}
+
+inline void
+evdev_set_methods(struct evdev_dev *evdev, void *softc,
+    struct evdev_methods *methods)
+{
+
+	evdev->ev_methods = methods;
+	evdev->ev_softc = softc;
+}
+
+inline int
+evdev_support_prop(struct evdev_dev *evdev, uint16_t prop)
+{
+
+	if (prop >= INPUT_PROP_CNT)
+		return (EINVAL);
+
+	bit_set(evdev->ev_prop_flags, prop);
+	return (0);
+}
+
+inline int
+evdev_support_event(struct evdev_dev *evdev, uint16_t type)
+{
+
+	if (type >= EV_CNT)
+		return (EINVAL);
+
+	bit_set(evdev->ev_type_flags, type);
+	return (0);
+}
+
+inline int
+evdev_support_key(struct evdev_dev *evdev, uint16_t code)
+{
+
+	if (code >= KEY_CNT)
+		return (EINVAL);
+
+	bit_set(evdev->ev_key_flags, code);
+	return (0);
+}
+
+inline int
+evdev_support_rel(struct evdev_dev *evdev, uint16_t code)
+{
+
+	if (code >= REL_CNT)
+		return (EINVAL);
+
+	bit_set(evdev->ev_rel_flags, code);
+	return (0);
+}
+
+inline int
+evdev_support_abs(struct evdev_dev *evdev, uint16_t code,
+    struct input_absinfo *absinfo)
+{
+	int ret;
+
+	ret = evdev_set_absinfo(evdev, code, absinfo);
+	if (ret)
+		return (ret);
+
+	return (evdev_set_abs_bit(evdev, code));
+}
+
+inline int
+evdev_set_abs_bit(struct evdev_dev *evdev, uint16_t code)
+{
+	if (code >= ABS_CNT)
+		return (EINVAL);
+
+	if (evdev->ev_absinfo == NULL)
+		evdev->ev_absinfo = evdev_alloc_absinfo();
+
+	bit_set(evdev->ev_abs_flags, code);
+	return (0);
+}
+
+inline int
+evdev_support_msc(struct evdev_dev *evdev, uint16_t code)
+{
+
+	if (code >= MSC_CNT)
+		return (EINVAL);
+
+	bit_set(evdev->ev_msc_flags, code);
+	return (0);
+}
+
+
+inline int
+evdev_support_led(struct evdev_dev *evdev, uint16_t code)
+{
+
+	if (code >= LED_CNT)
+		return (EINVAL);
+
+	bit_set(evdev->ev_led_flags, code);
+	return (0);
+}
+
+inline int
+evdev_support_snd(struct evdev_dev *evdev, uint16_t code)
+{
+
+	if (code >= SND_CNT)
+		return (EINVAL);
+
+	bit_set(evdev->ev_snd_flags, code);
+	return (0);
+}
+
+inline int
+evdev_support_sw(struct evdev_dev *evdev, uint16_t code)
+{
+	if (code >= SW_CNT)
+		return (EINVAL);
+
+	bit_set(evdev->ev_sw_flags, code);
+	return (0);
+}
+
+bool
+evdev_event_supported(struct evdev_dev *evdev, uint16_t type)
+{
+
+	if (type >= EV_CNT)
+		return (false);
+
+	return (bit_test(evdev->ev_type_flags, type));
+}
+
+inline int
+evdev_set_absinfo(struct evdev_dev *evdev, uint16_t axis,
+    struct input_absinfo *absinfo)
+{
+
+	if (axis >= ABS_CNT)
+		return (EINVAL);
+
+	if (axis == ABS_MT_SLOT &&
+	    (absinfo->maximum < 1 || absinfo->maximum >= MAX_MT_SLOTS))
+		return (EINVAL);
+
+	if (evdev->ev_absinfo == NULL)
+		evdev->ev_absinfo = evdev_alloc_absinfo();
+
+	if (axis == ABS_MT_SLOT)
+		evdev->ev_absinfo[ABS_MT_SLOT].maximum = absinfo->maximum;
+	else
+		memcpy(&evdev->ev_absinfo[axis], absinfo,
+		    sizeof(struct input_absinfo));
+
+	return (0);
+}
+
+inline void
+evdev_set_repeat_params(struct evdev_dev *evdev, uint16_t property, int value)
+{
+
+	KASSERT(property < REP_CNT, ("invalid evdev repeat property"));
+	evdev->ev_rep[property] = value;
+}
+
+inline int
+evdev_set_flag(struct evdev_dev *evdev, uint16_t flag)
+{
+
+	if (flag >= EVDEV_FLAG_CNT)
+		return (EINVAL);
+
+	bit_set(evdev->ev_flags, flag);
+	return(0);
+}
+
+static int
+evdev_check_event(struct evdev_dev *evdev, uint16_t type, uint16_t code,
+    int32_t value)
+{
+
+	/* Allow SYN events implicitly */
+	if (type != EV_SYN && !evdev_event_supported(evdev, type))
+		return (EINVAL);
+
+	switch (type) {
+	case EV_SYN:
+		if (code >= SYN_CNT)
+			return (EINVAL);
+		break;
+
+	case EV_KEY:
+		if (code >= KEY_CNT)
+			return (EINVAL);
+		if (!bit_test(evdev->ev_key_flags, code))
+			return (EINVAL);
+		break;
+
+	case EV_REL:
+		if (code >= REL_CNT)
+			return (EINVAL);
+		if (!bit_test(evdev->ev_rel_flags, code))
+			return (EINVAL);
+		break;
+
+	case EV_ABS:
+		if (code >= ABS_CNT)
+			return (EINVAL);
+		if (!bit_test(evdev->ev_abs_flags, code))
+			return (EINVAL);
+		if (code == ABS_MT_SLOT &&
+		    (value < 0 || value > MAXIMAL_MT_SLOT(evdev)))
+			return (EINVAL);
+		if (ABS_IS_MT(code) && evdev->ev_mt == NULL &&
+		    bit_test(evdev->ev_abs_flags, ABS_MT_SLOT))
+			return (EINVAL);
+		break;
+
+	case EV_MSC:
+		if (code >= MSC_CNT)
+			return (EINVAL);
+		if (!bit_test(evdev->ev_msc_flags, code))
+			return (EINVAL);
+		break;
+
+	case EV_LED:
+		if (code >= LED_CNT)
+			return (EINVAL);
+		if (!bit_test(evdev->ev_led_flags, code))
+			return (EINVAL);
+		break;
+
+	case EV_SND:
+		if (code >= SND_CNT)
+			return (EINVAL);
+		if (!bit_test(evdev->ev_snd_flags, code))
+			return (EINVAL);
+		break;
+
+	case EV_SW:
+		if (code >= SW_CNT)
+			return (EINVAL);
+		if (!bit_test(evdev->ev_sw_flags, code))
+			return (EINVAL);
+		break;
+
+	case EV_REP:
+		if (code >= REP_CNT)
+			return (EINVAL);
+		break;
+
+	default:
+		return (EINVAL);
+	}
+
+	return (0);
+}
+
+static void
+evdev_modify_event(struct evdev_dev *evdev, uint16_t type, uint16_t code,
+    int32_t *value)
+{
+
+	EVDEV_LOCK_ASSERT(evdev);
+
+	switch (type) {
+	case EV_KEY:
+		if (!evdev_event_supported(evdev, EV_REP))
+			break;
+
+		if (!bit_test(evdev->ev_flags, EVDEV_FLAG_SOFTREPEAT)) {
+			/* Detect driver key repeats. */
+			if (bit_test(evdev->ev_key_states, code) &&
+			    *value == KEY_EVENT_DOWN)
+				*value = KEY_EVENT_REPEAT;
+		} else {
+			/* Start/stop callout for evdev repeats */
+			if (bit_test(evdev->ev_key_states, code) == !*value) {
+				if (*value == KEY_EVENT_DOWN)
+					evdev_start_repeat(evdev, code);
+				else
+					evdev_stop_repeat(evdev);
+			}
+		}
+		break;
+
+	case EV_ABS:
+		/* TBD: implement fuzz */
+		break;
+	}
+}
+
+static enum evdev_sparse_result
+evdev_sparse_event(struct evdev_dev *evdev, uint16_t type, uint16_t code,
+    int32_t value)
+{
+	int32_t last_mt_slot;
+
+	EVDEV_LOCK_ASSERT(evdev);
+
+	/*
+	 * For certain event types, update device state bits
+	 * and convert level reporting to edge reporting
+	 */
+	switch (type) {
+	case EV_KEY:
+		switch (value) {
+		case KEY_EVENT_UP:
+		case KEY_EVENT_DOWN:
+			if (bit_test(evdev->ev_key_states, code) == value)
+				return (EV_SKIP_EVENT);
+			bit_change(evdev->ev_key_states, code, value);
+			break;
+
+		case KEY_EVENT_REPEAT:
+			if (bit_test(evdev->ev_key_states, code) == 0 ||
+			    !evdev_event_supported(evdev, EV_REP))
+				return (EV_SKIP_EVENT);
+			break;
+
+		default:
+			 return (EV_SKIP_EVENT);
+		}
+		break;
+
+	case EV_LED:
+		if (bit_test(evdev->ev_led_states, code) == value)
+			return (EV_SKIP_EVENT);
+		bit_change(evdev->ev_led_states, code, value);
+		break;
+
+	case EV_SND:
+		if (bit_test(evdev->ev_snd_states, code) == value)
+			return (EV_SKIP_EVENT);
+		bit_change(evdev->ev_snd_states, code, value);
+		break;
+
+	case EV_SW:
+		if (bit_test(evdev->ev_sw_states, code) == value)
+			return (EV_SKIP_EVENT);
+		bit_change(evdev->ev_sw_states, code, value);
+		break;
+
+	case EV_REP:
+		if (evdev->ev_rep[code] == value)
+			return (EV_SKIP_EVENT);
+		evdev_set_repeat_params(evdev, code, value);
+		break;
+
+	case EV_REL:
+		if (value == 0)
+			return (EV_SKIP_EVENT);
+		break;
+
+	/* For EV_ABS, save last value in absinfo and ev_mt_states */
+	case EV_ABS:
+		switch (code) {
+		case ABS_MT_SLOT:
+			/* Postpone ABS_MT_SLOT till next event */
+			evdev_set_last_mt_slot(evdev, value);
+			return (EV_SKIP_EVENT);
+
+		case ABS_MT_FIRST ... ABS_MT_LAST:
+			/* Pass MT protocol type A events as is */
+			if (!bit_test(evdev->ev_abs_flags, ABS_MT_SLOT))
+				break;
+			/* Don`t repeat MT protocol type B events */
+			last_mt_slot = evdev_get_last_mt_slot(evdev);
+			if (evdev_get_mt_value(evdev, last_mt_slot, code)
+			     == value)
+				return (EV_SKIP_EVENT);
+			evdev_set_mt_value(evdev, last_mt_slot, code, value);
+			if (last_mt_slot != CURRENT_MT_SLOT(evdev)) {
+				CURRENT_MT_SLOT(evdev) = last_mt_slot;
+				evdev->ev_report_opened = true;
+				return (EV_REPORT_MT_SLOT);
+			}
+			break;
+
+		default:
+			if (evdev->ev_absinfo[code].value == value)
+				return (EV_SKIP_EVENT);
+			evdev->ev_absinfo[code].value = value;
+		}
+		break;
+
+	case EV_SYN:
+		if (code == SYN_REPORT) {
+			/* Skip empty reports */
+			if (!evdev->ev_report_opened)
+				return (EV_SKIP_EVENT);
+			evdev->ev_report_opened = false;
+			return (EV_REPORT_EVENT);
+		}
+		break;
+	}
+
+	evdev->ev_report_opened = true;
+	return (EV_REPORT_EVENT);
+}
+
+static void
+evdev_propagate_event(struct evdev_dev *evdev, uint16_t type, uint16_t code,
+    int32_t value)
+{
+	struct evdev_client *client;
+
+	debugf("%s pushed event %d/%d/%d",
+	    evdev->ev_shortname, type, code, value);
+
+	EVDEV_LOCK_ASSERT(evdev);
+
+	/* Propagate event through all clients */
+	LIST_FOREACH(client, &evdev->ev_clients, ec_link) {
+		if (evdev->ev_grabber != NULL && evdev->ev_grabber != client)
+			continue;
+
+		EVDEV_CLIENT_LOCKQ(client);
+		evdev_client_push(client, type, code, value);
+		if (type == EV_SYN && code == SYN_REPORT)
+			evdev_notify_event(client);
+		EVDEV_CLIENT_UNLOCKQ(client);
+	}
+
+	/* Update counters */
+	evdev->ev_event_count++;
+	if (type == EV_SYN && code == SYN_REPORT)
+		evdev->ev_report_count++;
+}
+
+void
+evdev_send_event(struct evdev_dev *evdev, uint16_t type, uint16_t code,
+    int32_t value)
+{
+	enum evdev_sparse_result sparse;
+
+	EVDEV_LOCK_ASSERT(evdev);
+
+	sparse =  evdev_sparse_event(evdev, type, code, value);
+	switch (sparse) {
+	case EV_REPORT_MT_SLOT:
+		/* report postponed ABS_MT_SLOT */
+		evdev_propagate_event(evdev, EV_ABS, ABS_MT_SLOT,
+		    CURRENT_MT_SLOT(evdev));
+		/* FALLTHROUGH */
+	case EV_REPORT_EVENT:
+		evdev_propagate_event(evdev, type, code, value);
+		/* FALLTHROUGH */
+	case EV_SKIP_EVENT:
+		break;
+	}
+}
+
+int
+evdev_push_event(struct evdev_dev *evdev, uint16_t type, uint16_t code,
+    int32_t value)
+{
+
+	if (evdev_check_event(evdev, type, code, value) != 0)
+		return (EINVAL);
+
+	EVDEV_LOCK(evdev);
+	evdev_modify_event(evdev, type, code, &value);
+	if (type == EV_SYN && code == SYN_REPORT && evdev->ev_report_opened &&
+	    bit_test(evdev->ev_flags, EVDEV_FLAG_MT_STCOMPAT))
+		evdev_send_mt_compat(evdev);
+	evdev_send_event(evdev, type, code, value);
+	EVDEV_UNLOCK(evdev);
+
+	return (0);
+}
+
+int
+evdev_inject_event(struct evdev_dev *evdev, uint16_t type, uint16_t code,
+    int32_t value)
+{
+	int ret = 0;
+
+	switch (type) {
+	case EV_REP:
+		/* evdev repeats should not be processed by hardware driver */
+		if (bit_test(evdev->ev_flags, EVDEV_FLAG_SOFTREPEAT))
+			goto push;
+		/* FALLTHROUGH */
+	case EV_LED:
+	case EV_MSC:
+	case EV_SND:
+	case EV_FF:
+		if (evdev->ev_methods != NULL &&
+		    evdev->ev_methods->ev_event != NULL)
+			evdev->ev_methods->ev_event(evdev, evdev->ev_softc,
+			    type, code, value);
+		/*
+		 * Leds and driver repeats should be reported in ev_event
+		 * method body to interoperate with kbdmux states and rates
+		 * propagation so both ways (ioctl and evdev) of changing it
+		 * will produce only one evdev event report to client.
+		 */
+		if (type == EV_LED || type == EV_REP)
+			break;
+		/* FALLTHROUGH */
+	case EV_SYN:
+	case EV_KEY:
+	case EV_REL:
+	case EV_ABS:
+	case EV_SW:
+push:
+		ret = evdev_push_event(evdev, type,  code, value);
+		break;
+
+	default:
+		ret = EINVAL;
+	}
+
+	return (ret);
+}
+
+inline int
+evdev_sync(struct evdev_dev *evdev)
+{
+
+	return (evdev_push_event(evdev, EV_SYN, SYN_REPORT, 1));
+}
+
+
+inline int
+evdev_mt_sync(struct evdev_dev *evdev)
+{
+
+	return (evdev_push_event(evdev, EV_SYN, SYN_MT_REPORT, 1));
+}
+
+int
+evdev_register_client(struct evdev_dev *evdev, struct evdev_client *client)
+{
+	int ret = 0;
+
+	debugf("adding new client for device %s", evdev->ev_shortname);
+
+	EVDEV_LOCK_ASSERT(evdev);
+
+	if (LIST_EMPTY(&evdev->ev_clients) && evdev->ev_methods != NULL &&
+	    evdev->ev_methods->ev_open != NULL) {
+		debugf("calling ev_open() on device %s", evdev->ev_shortname);
+		ret = evdev->ev_methods->ev_open(evdev, evdev->ev_softc);
+	}
+	if (ret == 0)
+		LIST_INSERT_HEAD(&evdev->ev_clients, client, ec_link);
+	return (ret);
+}
+
+void
+evdev_dispose_client(struct evdev_dev *evdev, struct evdev_client *client)
+{
+	debugf("removing client for device %s", evdev->ev_shortname);
+
+	EVDEV_LOCK_ASSERT(evdev);
+
+	LIST_REMOVE(client, ec_link);
+	if (LIST_EMPTY(&evdev->ev_clients)) {
+		if (evdev->ev_methods != NULL &&
+		    evdev->ev_methods->ev_close != NULL)
+			evdev->ev_methods->ev_close(evdev, evdev->ev_softc);
+		if (evdev_event_supported(evdev, EV_REP) &&
+		    bit_test(evdev->ev_flags, EVDEV_FLAG_SOFTREPEAT))
+			evdev_stop_repeat(evdev);
+	}
+	evdev_release_client(evdev, client);
+}
+
+int
+evdev_grab_client(struct evdev_dev *evdev, struct evdev_client *client)
+{
+
+	EVDEV_LOCK_ASSERT(evdev);
+
+	if (evdev->ev_grabber != NULL)
+		return (EBUSY);
+
+	evdev->ev_grabber = client;
+
+	return (0);
+}
+
+int
+evdev_release_client(struct evdev_dev *evdev, struct evdev_client *client)
+{
+
+	EVDEV_LOCK_ASSERT(evdev);
+
+	if (evdev->ev_grabber != client)
+		return (EINVAL);
+
+	evdev->ev_grabber = NULL;
+
+	return (0);
+}
+
+static void
+evdev_assign_id(struct evdev_dev *dev)
+{
+	device_t parent;
+	devclass_t devclass;
+	const char *classname;
+
+	if (dev->ev_id.bustype != 0)
+		return;
+
+	if (dev->ev_dev == NULL) {
+		dev->ev_id.bustype = BUS_VIRTUAL;
+		return;
+	}
+
+	parent = device_get_parent(dev->ev_dev);
+	if (parent == NULL) {
+		dev->ev_id.bustype = BUS_HOST;
+		return;
+	}
+
+	devclass = device_get_devclass(parent);
+	classname = devclass_get_name(devclass);
+
+	debugf("parent bus classname: %s", classname);
+
+	if (strcmp(classname, "pci") == 0) {
+		dev->ev_id.bustype = BUS_PCI;
+		dev->ev_id.vendor = pci_get_vendor(dev->ev_dev);
+		dev->ev_id.product = pci_get_device(dev->ev_dev);
+		dev->ev_id.version = pci_get_revid(dev->ev_dev);
+		return;
+	}
+
+	if (strcmp(classname, "uhub") == 0) {
+		struct usb_attach_arg *uaa = device_get_ivars(dev->ev_dev);
+		dev->ev_id.bustype = BUS_USB;
+		dev->ev_id.vendor = uaa->info.idVendor;
+		dev->ev_id.product = uaa->info.idProduct;
+		return;
+	}
+
+	if (strcmp(classname, "atkbdc") == 0) {
+		devclass = device_get_devclass(dev->ev_dev);
+		classname = devclass_get_name(devclass);
+		dev->ev_id.bustype = BUS_I8042;
+		if (strcmp(classname, "atkbd") == 0) {
+			dev->ev_id.vendor = PS2_KEYBOARD_VENDOR;
+			dev->ev_id.product = PS2_KEYBOARD_PRODUCT;
+		} else if (strcmp(classname, "psm") == 0) {
+			dev->ev_id.vendor = PS2_MOUSE_VENDOR;
+			dev->ev_id.product = PS2_MOUSE_GENERIC_PRODUCT;
+		}
+		return;
+	}
+
+	dev->ev_id.bustype = BUS_HOST;
+}
+
+static void
+evdev_repeat_callout(void *arg)
+{
+	struct evdev_dev *evdev = (struct evdev_dev *)arg;
+
+	evdev_send_event(evdev, EV_KEY, evdev->ev_rep_key, KEY_EVENT_REPEAT);
+	evdev_send_event(evdev, EV_SYN, SYN_REPORT, 1);
+
+	if (evdev->ev_rep[REP_PERIOD])
+		callout_reset(&evdev->ev_rep_callout,
+		    evdev->ev_rep[REP_PERIOD] * hz / 1000,
+		    evdev_repeat_callout, evdev);
+	else
+		evdev->ev_rep_key = KEY_RESERVED;
+}
+
+static void
+evdev_start_repeat(struct evdev_dev *evdev, uint16_t key)
+{
+
+	EVDEV_LOCK_ASSERT(evdev);
+
+	if (evdev->ev_rep[REP_DELAY]) {
+		evdev->ev_rep_key = key;
+		callout_reset(&evdev->ev_rep_callout,
+		    evdev->ev_rep[REP_DELAY] * hz / 1000,
+		    evdev_repeat_callout, evdev);
+	}
+}
+
+static void
+evdev_stop_repeat(struct evdev_dev *evdev)
+{
+
+	EVDEV_LOCK_ASSERT(evdev);
+
+	if (evdev->ev_rep_key != KEY_RESERVED) {
+		callout_stop(&evdev->ev_rep_callout);
+		evdev->ev_rep_key = KEY_RESERVED;
+	}
+}

--- a/sys/dev/evdev/evdev.h
+++ b/sys/dev/evdev/evdev.h
@@ -1,0 +1,262 @@
+/*-
+ * Copyright (c) 2014 Jakub Wojciech Klama <jceel@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef	_DEV_EVDEV_EVDEV_H
+#define	_DEV_EVDEV_EVDEV_H
+
+#include <sys/bitstring.h>
+#include <sys/queue.h>
+#include <sys/malloc.h>
+#include <sys/kbio.h>
+#include <sys/selinfo.h>
+#include <dev/evdev/input.h>
+#include <dev/kbd/kbdreg.h>
+
+#define	NAMELEN		80
+
+/*
+ * bitstr_t implementation must be identical to one found in EVIOCG*
+ * libevdev ioctls. Our bitstring(3) API is compatible since r299090.
+ */
+_Static_assert(sizeof(bitstr_t) == sizeof(unsigned long),
+    "bitstr_t size mismatch");
+
+MALLOC_DECLARE(M_EVDEV);
+
+struct evdev_dev;
+struct evdev_client;
+struct evdev_mt;
+
+typedef int (evdev_open_t)(struct evdev_dev *, void *);
+typedef void (evdev_close_t)(struct evdev_dev *, void *);
+typedef void (evdev_event_t)(struct evdev_dev *, void *, uint16_t,
+    uint16_t, int32_t);
+typedef void (evdev_keycode_t)(struct evdev_dev *, void *,
+    struct input_keymap_entry *);
+typedef void (evdev_client_event_t)(struct evdev_client *, void *);
+
+#define	ABS_MT_FIRST	ABS_MT_TOUCH_MAJOR
+#define	ABS_MT_LAST	ABS_MT_TOOL_Y
+#define	ABS_IS_MT(x)	((x) >= ABS_MT_FIRST && (x) <= ABS_MT_LAST)
+#define	ABS_MT_INDEX(x)	((x) - ABS_MT_FIRST)
+#define	MT_CNT		(ABS_MT_INDEX(ABS_MT_LAST) + 1)
+/* Multitouch protocol type A */
+#define	MAX_MT_REPORTS	5
+/* Multitouch protocol type B interface */
+#define	MAX_MT_SLOTS	16
+#define	CURRENT_MT_SLOT(evdev)	((evdev)->ev_absinfo[ABS_MT_SLOT].value)
+#define	MAXIMAL_MT_SLOT(evdev)	((evdev)->ev_absinfo[ABS_MT_SLOT].maximum)
+
+#define	EVDEV_FLAG_SOFTREPEAT	0x00	/* use evdev to repeat keys */
+#define	EVDEV_FLAG_MT_STCOMPAT	0x01	/* autogenerate ST-compatible events
+					 * for MT protocol type B reports */
+#define	EVDEV_FLAG_MAX		0x1F
+#define	EVDEV_FLAG_CNT		(EVDEV_FLAG_MAX + 1)
+
+enum evdev_key_events
+{
+	KEY_EVENT_UP,
+	KEY_EVENT_DOWN,
+	KEY_EVENT_REPEAT
+};
+
+/* evdev clock IDs in Linux semantic */
+enum evdev_clock_id
+{
+	EV_CLOCK_REALTIME = 0,	/* UTC clock */
+	EV_CLOCK_MONOTONIC,	/* monotonic, stops on suspend */
+	EV_CLOCK_BOOTTIME	/* monotonic, suspend-awared */
+};
+
+#define	PS2_KEYBOARD_VENDOR		1
+#define	PS2_KEYBOARD_PRODUCT		1
+#define	PS2_MOUSE_VENDOR		2
+#define	PS2_MOUSE_GENERIC_PRODUCT	1
+
+struct evdev_methods
+{
+	evdev_open_t		*ev_open;
+	evdev_close_t		*ev_close;
+	evdev_event_t		*ev_event;
+	evdev_keycode_t		*ev_get_keycode;
+	evdev_keycode_t		*ev_set_keycode;
+};
+
+struct evdev_dev
+{
+	char			ev_name[NAMELEN];
+	char			ev_shortname[NAMELEN];
+	char			ev_serial[NAMELEN];
+	device_t		ev_dev;
+	struct cdev *		ev_cdev;
+	int			ev_unit;
+	struct mtx		ev_mtx;
+	struct input_id		ev_id;
+	struct evdev_client *	ev_grabber;
+	size_t			ev_report_size;
+
+	/* Supported features: */
+	bitstr_t		bit_decl(ev_prop_flags, INPUT_PROP_CNT);
+	bitstr_t		bit_decl(ev_type_flags, EV_CNT);
+	bitstr_t		bit_decl(ev_key_flags, KEY_CNT);
+	bitstr_t		bit_decl(ev_rel_flags, REL_CNT);
+	bitstr_t		bit_decl(ev_abs_flags, ABS_CNT);
+	bitstr_t		bit_decl(ev_msc_flags, MSC_CNT);
+	bitstr_t		bit_decl(ev_led_flags, LED_CNT);
+	bitstr_t		bit_decl(ev_snd_flags, SND_CNT);
+	bitstr_t		bit_decl(ev_sw_flags, SW_CNT);
+	struct input_absinfo *	ev_absinfo;
+	bitstr_t		bit_decl(ev_flags, EVDEV_FLAG_CNT);
+
+	/* Repeat parameters & callout: */
+	int			ev_rep[REP_CNT];
+	struct callout		ev_rep_callout;
+	uint16_t		ev_rep_key;
+
+	/* State: */
+	bitstr_t		bit_decl(ev_key_states, KEY_CNT);
+	bitstr_t		bit_decl(ev_led_states, LED_CNT);
+	bitstr_t		bit_decl(ev_snd_states, SND_CNT);
+	bitstr_t		bit_decl(ev_sw_states, SW_CNT);
+	bool			ev_report_opened;
+
+	/* Multitouch protocol type B state: */
+	struct evdev_mt *	ev_mt;
+
+	/* Counters: */
+	uint64_t		ev_event_count;
+	uint64_t		ev_report_count;
+
+	/* Parent driver callbacks: */
+	struct evdev_methods *	ev_methods;
+	void *			ev_softc;
+
+	LIST_ENTRY(evdev_dev) ev_link;
+	LIST_HEAD(, evdev_client) ev_clients;
+};
+
+#define	EVDEV_LOCK(evdev)		mtx_lock(&(evdev)->ev_mtx)
+#define	EVDEV_UNLOCK(evdev)		mtx_unlock(&(evdev)->ev_mtx)
+#define	EVDEV_LOCK_ASSERT(evdev)	mtx_assert(&(evdev)->ev_mtx, MA_OWNED)
+
+struct evdev_client
+{
+	struct evdev_dev *	ec_evdev;
+	struct mtx		ec_buffer_mtx;
+	size_t			ec_buffer_size;
+	size_t			ec_buffer_head;
+	size_t			ec_buffer_tail;
+	size_t			ec_buffer_ready;
+	enum evdev_clock_id	ec_clock_id;
+	struct selinfo		ec_selp;
+	struct sigio *		ec_sigio;
+	bool			ec_async;
+	bool			ec_revoked;
+	bool			ec_blocked;
+	bool			ec_selected;
+
+	LIST_ENTRY(evdev_client) ec_link;
+
+	struct input_event	ec_buffer[];
+};
+
+#define	EVDEV_CLIENT_LOCKQ(client)	mtx_lock(&(client)->ec_buffer_mtx)
+#define	EVDEV_CLIENT_UNLOCKQ(client)	mtx_unlock(&(client)->ec_buffer_mtx)
+#define EVDEV_CLIENT_LOCKQ_ASSERT(client) \
+    mtx_assert(&(client)->ec_buffer_mtx, MA_OWNED)
+#define	EVDEV_CLIENT_EMPTYQ(client) \
+    ((client)->ec_buffer_head == (client)->ec_buffer_ready)
+#define	EVDEV_CLIENT_SIZEQ(client) \
+    (((client)->ec_buffer_ready + (client)->ec_buffer_size - \
+      (client)->ec_buffer_head) % (client)->ec_buffer_size)
+
+/* Input device interface: */
+struct evdev_dev *evdev_alloc(void);
+void evdev_free(struct evdev_dev *);
+void evdev_set_name(struct evdev_dev *, const char *);
+void evdev_set_phys(struct evdev_dev *, const char *);
+void evdev_set_serial(struct evdev_dev *, const char *);
+void evdev_set_methods(struct evdev_dev *, void *, struct evdev_methods *);
+int evdev_register(device_t, struct evdev_dev *);
+int evdev_unregister(device_t, struct evdev_dev *);
+int evdev_push_event(struct evdev_dev *, uint16_t, uint16_t, int32_t);
+void evdev_send_event(struct evdev_dev *, uint16_t, uint16_t, int32_t);
+int evdev_inject_event(struct evdev_dev *, uint16_t, uint16_t, int32_t);
+int evdev_sync(struct evdev_dev *);
+int evdev_mt_sync(struct evdev_dev *);
+int evdev_cdev_create(struct evdev_dev *);
+int evdev_cdev_destroy(struct evdev_dev *);
+int evdev_support_prop(struct evdev_dev *, uint16_t);
+int evdev_support_event(struct evdev_dev *, uint16_t);
+int evdev_support_key(struct evdev_dev *, uint16_t);
+int evdev_support_rel(struct evdev_dev *, uint16_t);
+int evdev_support_abs(struct evdev_dev *, uint16_t, struct input_absinfo *);
+int evdev_support_msc(struct evdev_dev *, uint16_t);
+int evdev_support_led(struct evdev_dev *, uint16_t);
+int evdev_support_snd(struct evdev_dev *, uint16_t);
+int evdev_support_sw(struct evdev_dev *, uint16_t);
+bool evdev_event_supported(struct evdev_dev *, uint16_t);
+int evdev_set_abs_bit(struct evdev_dev *, uint16_t);
+int evdev_set_absinfo(struct evdev_dev *, uint16_t, struct input_absinfo *);
+void evdev_set_repeat_params(struct evdev_dev *, uint16_t, int);
+int evdev_set_report_size(struct evdev_dev *, size_t);
+int evdev_set_flag(struct evdev_dev *, uint16_t);
+
+/* Client interface: */
+int evdev_register_client(struct evdev_dev *, struct evdev_client *);
+void evdev_dispose_client(struct evdev_dev *, struct evdev_client *);
+int evdev_grab_client(struct evdev_dev *, struct evdev_client *);
+int evdev_release_client(struct evdev_dev *, struct evdev_client *);
+void evdev_client_push(struct evdev_client *, uint16_t, uint16_t, int32_t);
+void evdev_notify_event(struct evdev_client *);
+
+/* Multitouch related functions: */
+void evdev_mt_init(struct evdev_dev *);
+void evdev_mt_free(struct evdev_dev *);
+int32_t evdev_get_last_mt_slot(struct evdev_dev *);
+void evdev_set_last_mt_slot(struct evdev_dev *, int32_t);
+int32_t evdev_get_mt_value(struct evdev_dev *, int32_t, int16_t);
+void evdev_set_mt_value(struct evdev_dev *, int32_t, int16_t, int32_t);
+int32_t evdev_get_mt_slot_by_tracking_id(struct evdev_dev *, int32_t);
+void evdev_support_nfingers(struct evdev_dev *, int32_t);
+void evdev_support_mt_compat(struct evdev_dev *);
+void evdev_push_nfingers(struct evdev_dev *, int32_t);
+void evdev_send_mt_compat(struct evdev_dev *);
+void evdev_push_mt_compat(struct evdev_dev *);
+
+/* Utility functions: */
+uint16_t evdev_hid2key(int);
+void evdev_support_all_known_keys(struct evdev_dev *);
+uint16_t evdev_scancode2key(int *, int);
+void evdev_client_dumpqueue(struct evdev_client *);
+void evdev_push_mouse_btn(struct evdev_dev *, int);
+void evdev_push_leds(struct evdev_dev *, int);
+void evdev_push_repeats(struct evdev_dev *, keyboard_t *);
+evdev_event_t evdev_ev_kbd_event;
+
+#endif	/* _DEV_EVDEV_EVDEV_H */

--- a/sys/dev/evdev/evdev_mt.c
+++ b/sys/dev/evdev/evdev_mt.c
@@ -1,0 +1,263 @@
+/*-
+ * Copyright (c) 2016 Vladimir Kondratyev <wulf@cicgroup.ru>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#include <sys/param.h>
+#include <sys/malloc.h>
+#include <sys/lock.h>
+#include <sys/mutex.h>
+#include <sys/systm.h>
+
+#include <dev/evdev/input.h>
+#include <dev/evdev/evdev.h>
+
+#ifdef DEBUG
+#define	debugf(fmt, args...)	printf("evdev: " fmt "\n", ##args)
+#else
+#define	debugf(fmt, args...)
+#endif
+
+static uint16_t evdev_fngmap[] = {
+	BTN_TOOL_FINGER,
+	BTN_TOOL_DOUBLETAP,
+	BTN_TOOL_TRIPLETAP,
+	BTN_TOOL_QUADTAP,
+	BTN_TOOL_QUINTTAP,
+};
+
+static uint16_t evdev_mtstmap[][2] = {
+	{ ABS_MT_POSITION_X, ABS_X },
+	{ ABS_MT_POSITION_Y, ABS_Y },
+	{ ABS_MT_PRESSURE, ABS_PRESSURE },
+	{ ABS_MT_TOUCH_MAJOR, ABS_TOOL_WIDTH },
+};
+
+struct evdev_mt_slot {
+	uint64_t ev_report;
+	int32_t ev_mt_states[MT_CNT];
+};
+
+struct evdev_mt {
+	int32_t	ev_mt_last_reported_slot;
+	struct evdev_mt_slot ev_mt_slots[];
+};
+
+void
+evdev_mt_init(struct evdev_dev *evdev)
+{
+	int32_t slot, slots;
+
+	slots = MAXIMAL_MT_SLOT(evdev) + 1;
+
+	evdev->ev_mt = malloc(offsetof(struct evdev_mt, ev_mt_slots) +
+	     sizeof(struct evdev_mt_slot) * slots, M_EVDEV, M_WAITOK | M_ZERO);
+
+	/* Initialize multitouch protocol type B states */
+	for (slot = 0; slot < slots; slot++) {
+		/*
+		 * .ev_report should not be initialized to initial value of
+		 * report counter (0) as it brokes free slot detection in
+		 * evdev_get_mt_slot_by_tracking_id. So initialize it to -1
+		 */
+		evdev->ev_mt->ev_mt_slots[slot] = (struct evdev_mt_slot) {
+			.ev_report = 0xFFFFFFFFFFFFFFFFULL,
+			.ev_mt_states[ABS_MT_INDEX(ABS_MT_TRACKING_ID)] = -1,
+		};
+	}
+
+	if (bit_test(evdev->ev_flags, EVDEV_FLAG_MT_STCOMPAT))
+		evdev_support_mt_compat(evdev);
+}
+
+void
+evdev_mt_free(struct evdev_dev *evdev)
+{
+
+	free(evdev->ev_mt, M_EVDEV);
+}
+
+int32_t
+evdev_get_last_mt_slot(struct evdev_dev *evdev)
+{
+
+	return (evdev->ev_mt->ev_mt_last_reported_slot);
+}
+
+void
+evdev_set_last_mt_slot(struct evdev_dev *evdev, int32_t slot)
+{
+
+	evdev->ev_mt->ev_mt_last_reported_slot = slot;
+}
+
+inline int32_t
+evdev_get_mt_value(struct evdev_dev *evdev, int32_t slot, int16_t code)
+{
+
+	return (evdev->ev_mt->
+	    ev_mt_slots[slot].ev_mt_states[ABS_MT_INDEX(code)]);
+}
+
+inline void
+evdev_set_mt_value(struct evdev_dev *evdev, int32_t slot, int16_t code,
+    int32_t value)
+{
+
+	if (code == ABS_MT_TRACKING_ID && value == -1)
+		evdev->ev_mt->ev_mt_slots[slot].ev_report =
+		    evdev->ev_report_count;
+
+	evdev->ev_mt->ev_mt_slots[slot].ev_mt_states[ABS_MT_INDEX(code)] =
+	    value;
+}
+
+int32_t
+evdev_get_mt_slot_by_tracking_id(struct evdev_dev *evdev, int32_t tracking_id)
+{
+	int32_t tr_id, slot, free_slot = -1;
+
+	for (slot = 0; slot <= MAXIMAL_MT_SLOT(evdev); slot++) {
+		tr_id = evdev_get_mt_value(evdev, slot, ABS_MT_TRACKING_ID);
+		if (tr_id == tracking_id)
+			return (slot);
+		/*
+		 * Its possible that slot will be reassigned in a place of just
+		 * released one within the same report. To avoid this compare
+		 * report counter with slot`s report number updated with each
+		 * ABS_MT_TRACKING_ID change.
+		 */
+		if (free_slot == -1 && tr_id == -1 &&
+		    evdev->ev_mt->ev_mt_slots[slot].ev_report !=
+		    evdev->ev_report_count)
+			free_slot = slot;
+	}
+
+	return (free_slot);
+}
+
+void
+evdev_support_nfingers(struct evdev_dev *evdev, int32_t nfingers)
+{
+	int32_t i;
+
+	for (i = 0; i < MIN(nitems(evdev_fngmap), nfingers); i++)
+		evdev_support_key(evdev, evdev_fngmap[i]);
+}
+
+void
+evdev_support_mt_compat(struct evdev_dev *evdev)
+{
+	int32_t i;
+
+	if (evdev->ev_absinfo == NULL)
+		return;
+
+	evdev_support_event(evdev, EV_KEY);
+	evdev_support_key(evdev, BTN_TOUCH);
+
+	/* Touchscreens should not advertise tap tool capabilities */
+	if (!bit_test(evdev->ev_prop_flags, INPUT_PROP_DIRECT))
+		evdev_support_nfingers(evdev, MAXIMAL_MT_SLOT(evdev) + 1);
+
+	/* Echo 0-th MT-slot as ST-slot */
+	for (i = 0; i < nitems(evdev_mtstmap); i++)
+		if (bit_test(evdev->ev_abs_flags, evdev_mtstmap[i][0]))
+			evdev_support_abs(evdev, evdev_mtstmap[i][1],
+			    &evdev->ev_absinfo[evdev_mtstmap[i][0]]);
+}
+
+static int32_t
+evdev_count_fingers(struct evdev_dev *evdev)
+{
+	int32_t nfingers = 0, i;
+
+	for (i = 0; i <= MAXIMAL_MT_SLOT(evdev); i++)
+		if (evdev_get_mt_value(evdev, i, ABS_MT_TRACKING_ID) != -1)
+			nfingers++;
+
+	return (nfingers);
+}
+
+static void
+evdev_send_nfingers(struct evdev_dev *evdev, int32_t nfingers)
+{
+	int32_t i;
+
+	EVDEV_LOCK_ASSERT(evdev);
+
+	if (nfingers > nitems(evdev_fngmap))
+		nfingers = nitems(evdev_fngmap);
+
+	for (i = 0; i < nitems(evdev_fngmap); i++)
+		evdev_send_event(evdev, EV_KEY, evdev_fngmap[i],
+		    nfingers == i + 1);
+}
+
+void
+evdev_push_nfingers(struct evdev_dev *evdev, int32_t nfingers)
+{
+
+	EVDEV_LOCK(evdev);
+	evdev_send_nfingers(evdev, nfingers);
+	EVDEV_UNLOCK(evdev);
+}
+
+void
+evdev_send_mt_compat(struct evdev_dev *evdev)
+{
+	int32_t nfingers, i;
+
+	EVDEV_LOCK_ASSERT(evdev);
+
+	nfingers = evdev_count_fingers(evdev);
+	evdev_send_event(evdev, EV_KEY, BTN_TOUCH, nfingers > 0);
+
+	if (evdev_get_mt_value(evdev, 0, ABS_MT_TRACKING_ID) != -1)
+		/* Echo 0-th MT-slot as ST-slot */
+		for (i = 0; i < nitems(evdev_mtstmap); i++)
+			if (bit_test(evdev->ev_abs_flags, evdev_mtstmap[i][1]))
+				evdev_send_event(evdev, EV_ABS,
+				    evdev_mtstmap[i][1],
+				    evdev_get_mt_value(evdev, 0,
+				    evdev_mtstmap[i][0]));
+
+	/* Touchscreens should not report tool taps */
+	if (!bit_test(evdev->ev_prop_flags, INPUT_PROP_DIRECT))
+		evdev_send_nfingers(evdev, nfingers);
+
+	if (nfingers == 0)
+		evdev_send_event(evdev, EV_ABS, ABS_PRESSURE, 0);
+}
+
+void
+evdev_push_mt_compat(struct evdev_dev *evdev)
+{
+
+	EVDEV_LOCK(evdev);
+	evdev_send_mt_compat(evdev);
+	EVDEV_UNLOCK(evdev);
+}

--- a/sys/dev/evdev/evdev_utils.c
+++ b/sys/dev/evdev/evdev_utils.c
@@ -1,0 +1,334 @@
+/*-
+ * Copyright (c) 2014 Jakub Wojciech Klama <jceel@FreeBSD.org>
+ * Copyright (c) 2015-2016 Vladimir Kondratyev <wulf@cicgroup.ru>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/param.h>
+#include <sys/bus.h>
+#include <sys/kernel.h>
+#include <sys/conf.h>
+#include <sys/malloc.h>
+#include <sys/kbio.h>
+
+#include <dev/evdev/input.h>
+#include <dev/evdev/evdev.h>
+
+#include <dev/kbd/kbdreg.h>
+
+#define	NONE	KEY_RESERVED
+
+static uint16_t evdev_usb_scancodes[256] = {
+	/* 0x00 - 0x27 */
+	NONE,	NONE,	NONE,	NONE,	KEY_A,	KEY_B,	KEY_C,	KEY_D,
+	KEY_E,	KEY_F,	KEY_G,	KEY_H,	KEY_I,	KEY_J,	KEY_K,	KEY_L,
+	KEY_M,	KEY_N,	KEY_O,	KEY_P,	KEY_Q,	KEY_R,	KEY_S,	KEY_T,
+	KEY_U,	KEY_V,	KEY_W,	KEY_X,	KEY_Y,	KEY_Z,	KEY_1,	KEY_2,
+	KEY_3,	KEY_4,	KEY_5,	KEY_6,	KEY_7,	KEY_8,	KEY_9,	KEY_0,
+	/* 0x28 - 0x3f */
+	KEY_ENTER,	KEY_ESC,	KEY_BACKSPACE,	KEY_TAB,
+	KEY_SPACE,	KEY_MINUS,	KEY_EQUAL,	KEY_LEFTBRACE,
+	KEY_RIGHTBRACE,	KEY_BACKSLASH,	KEY_BACKSLASH,	KEY_SEMICOLON,
+	KEY_APOSTROPHE,	KEY_GRAVE,	KEY_COMMA,	KEY_DOT,
+	KEY_SLASH,	KEY_CAPSLOCK,	KEY_F1,		KEY_F2,
+	KEY_F3,		KEY_F4,		KEY_F5,		KEY_F6,
+	/* 0x40 - 0x5f */
+	KEY_F7,		KEY_F8,		KEY_F9,		KEY_F10,
+	KEY_F11,	KEY_F12,	KEY_SYSRQ,	KEY_SCROLLLOCK,
+	KEY_PAUSE,	KEY_INSERT,	KEY_HOME,	KEY_PAGEUP,
+	KEY_DELETE,	KEY_END,	KEY_PAGEDOWN,	KEY_RIGHT,
+	KEY_LEFT,	KEY_DOWN,	KEY_UP,		KEY_NUMLOCK,
+	KEY_SLASH,	KEY_KPASTERISK,	KEY_KPMINUS,	KEY_KPPLUS,
+	KEY_KPENTER,	KEY_KP1,	KEY_KP2,	KEY_KP3,
+	KEY_KP4,	KEY_KP5,	KEY_KP6,	KEY_KP7,
+	/* 0x60 - 0x7f */
+	KEY_KP8,	KEY_KP9,	KEY_KP0,	KEY_KPDOT,
+	KEY_102ND,	KEY_COMPOSE,	KEY_POWER,	KEY_KPEQUAL,
+	KEY_F13,	KEY_F14,	KEY_F15,	KEY_F16,
+	KEY_F17,	KEY_F18,	KEY_F19,	KEY_F20,
+	KEY_F21,	KEY_F22,	KEY_F23,	KEY_F24,
+	KEY_OPEN,	KEY_HELP,	KEY_PROPS,	KEY_FRONT,
+	KEY_STOP,	KEY_AGAIN,	KEY_UNDO,	KEY_CUT,
+	KEY_COPY,	KEY_PASTE,	KEY_FIND,	KEY_MUTE,
+	/* 0x80 - 0x9f */
+	KEY_VOLUMEUP,	KEY_VOLUMEDOWN,	NONE,		NONE,
+	NONE,		KEY_KPCOMMA,	NONE,		KEY_RO,
+	KEY_KATAKANAHIRAGANA,	KEY_YEN,KEY_HENKAN,	KEY_MUHENKAN,
+	KEY_KPJPCOMMA,	NONE,		NONE,		NONE,
+	KEY_HANGEUL,	KEY_HANJA,	KEY_KATAKANA,	KEY_HIRAGANA,
+	KEY_ZENKAKUHANKAKU,	NONE,	NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	/* 0xa0 - 0xbf */
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	/* 0xc0 - 0xdf */
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	/* 0xe0 - 0xff */
+	KEY_LEFTCTRL,	KEY_LEFTSHIFT,	KEY_LEFTALT,	KEY_LEFTMETA,
+	KEY_RIGHTCTRL,	KEY_RIGHTSHIFT,	KEY_RIGHTALT,	KEY_RIGHTMETA,
+	KEY_PLAYPAUSE,	KEY_STOPCD,	KEY_PREVIOUSSONG,KEY_NEXTSONG,
+	KEY_EJECTCD,	KEY_VOLUMEUP,	KEY_VOLUMEDOWN,	KEY_MUTE,
+	KEY_WWW,	KEY_BACK,	KEY_FORWARD,	KEY_STOP,
+	KEY_FIND,	KEY_SCROLLUP,	KEY_SCROLLDOWN,	KEY_EDIT,
+	KEY_SLEEP,	KEY_COFFEE,	KEY_REFRESH,	KEY_CALC,
+	NONE,		NONE,		NONE,		NONE,
+
+};
+
+static uint16_t evdev_at_set1_scancodes[] = {
+	/* 0x00 - 0x1f */
+	NONE,		KEY_ESC,	KEY_1,		KEY_2,
+	KEY_3,		KEY_4,		KEY_5,		KEY_6,
+	KEY_7,		KEY_8,		KEY_9,		KEY_0,
+	KEY_MINUS,	KEY_EQUAL,	KEY_BACKSPACE,	KEY_TAB,
+	KEY_Q,		KEY_W,		KEY_E,		KEY_R,
+	KEY_T,		KEY_Y,		KEY_U,		KEY_I,
+	KEY_O,		KEY_P,		KEY_LEFTBRACE,	KEY_RIGHTBRACE,
+	KEY_ENTER,	KEY_LEFTCTRL,	KEY_A,		KEY_S,
+	/* 0x20 - 0x3f */
+	KEY_D,		KEY_F,		KEY_G,		KEY_H,
+	KEY_J,		KEY_K,		KEY_L,		KEY_SEMICOLON,
+	KEY_APOSTROPHE,	KEY_GRAVE,	KEY_LEFTSHIFT,	KEY_BACKSLASH,
+	KEY_Z,		KEY_X,		KEY_C,		KEY_V,
+	KEY_B,		KEY_N,		KEY_M,		KEY_COMMA,
+	KEY_DOT,	KEY_SLASH,	KEY_RIGHTSHIFT,	NONE,
+	KEY_LEFTALT,	KEY_SPACE,	KEY_CAPSLOCK,	KEY_F1,
+	KEY_F2,		KEY_F3,		KEY_F4,		KEY_F5,
+	/* 0x40 - 0x5f */
+	KEY_F6,		KEY_F7,		KEY_F8,		KEY_F9,
+	KEY_F10,	KEY_NUMLOCK,	KEY_SCROLLLOCK,	KEY_KP7,
+	KEY_KP8,	KEY_KP9,	KEY_KPMINUS,	KEY_KP4,
+	KEY_KP5,	KEY_KP6,	KEY_KPPLUS,	KEY_KP1,
+	KEY_KP2,	KEY_KP3,	KEY_KP0,	KEY_KPDOT,
+	NONE,		NONE,		NONE,		KEY_F11,
+	KEY_F12,	NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	/* 0x60 - 0x7f */
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	KEY_KATAKANAHIRAGANA,	NONE,	NONE,		KEY_RO,
+	NONE,		NONE,	KEY_ZENKAKUHANKAKU,	KEY_HIRAGANA,
+	KEY_KATAKANA,	KEY_HENKAN,	NONE,		KEY_MUHENKAN,
+	NONE,		KEY_YEN,	KEY_KPCOMMA,	NONE,
+	/* 0x00 - 0x1f. 0xE0 prefixed */
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	KEY_PREVIOUSSONG,	NONE,	NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		KEY_NEXTSONG,	NONE,		NONE,
+	NONE,		KEY_KPENTER,	KEY_RIGHTCTRL,	NONE,
+	/* 0x20 - 0x3f. 0xE0 prefixed */
+	KEY_MUTE,	KEY_CALC,	KEY_PLAYPAUSE,	NONE,
+	KEY_STOPCD,	NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		KEY_VOLUMEDOWN,	NONE,
+	KEY_VOLUMEUP,	NONE,		KEY_HOMEPAGE,	NONE,
+	NONE,		KEY_KPASTERISK,	NONE,		KEY_SYSRQ,
+	KEY_RIGHTALT,	NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	/* 0x40 - 0x5f. 0xE0 prefixed */
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		KEY_PAUSE,	KEY_HOME,
+	KEY_UP,		KEY_PAGEUP,	NONE,		KEY_LEFT,
+	NONE,		KEY_RIGHT,	NONE,		KEY_END,
+	KEY_DOWN,	KEY_PAGEDOWN,	KEY_INSERT,	KEY_DELETE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		KEY_LEFTMETA,
+	KEY_RIGHTMETA,	KEY_MENU,	KEY_POWER,	KEY_SLEEP,
+	/* 0x60 - 0x7f. 0xE0 prefixed */
+	NONE,		NONE,		NONE,		KEY_WAKEUP,
+	NONE,		KEY_SEARCH,	KEY_BOOKMARKS,	KEY_REFRESH,
+	KEY_STOP,	KEY_FORWARD,	KEY_BACK,	KEY_COMPUTER,
+	KEY_MAIL,	KEY_MEDIA,	NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+	NONE,		NONE,		NONE,		NONE,
+};
+
+static uint16_t evdev_mouse_button_codes[] = {
+	BTN_LEFT,
+	BTN_MIDDLE,
+	BTN_RIGHT,
+	BTN_SIDE,
+	BTN_EXTRA,
+	BTN_FORWARD,
+	BTN_BACK,
+	BTN_TASK,
+};
+
+static uint16_t evdev_led_codes[] = {
+	LED_CAPSL,	/* CLKED */
+	LED_NUML,	/* NLKED */
+	LED_SCROLLL,	/* SLKED */
+};
+
+inline uint16_t
+evdev_hid2key(int scancode)
+{
+	return evdev_usb_scancodes[scancode];
+}
+
+inline void
+evdev_support_all_known_keys(struct evdev_dev *evdev)
+{
+	size_t i;
+
+	for (i = KEY_RESERVED; i < nitems(evdev_at_set1_scancodes); i++)
+		if (evdev_at_set1_scancodes[i] != NONE)
+			evdev_support_key(evdev, evdev_at_set1_scancodes[i]);
+}
+
+inline uint16_t
+evdev_scancode2key(int *state, int scancode)
+{
+	uint16_t keycode;
+
+	/* translate the scan code into a keycode */
+	keycode = evdev_at_set1_scancodes[scancode & 0x7f];
+	switch (*state) {
+	case 0x00:	/* normal scancode */
+		switch(scancode) {
+		case 0xE0:
+		case 0xE1:
+			*state = scancode;
+			return (NONE);
+		}
+		break;
+	case 0xE0:		/* 0xE0 prefix */
+		*state = 0;
+		keycode = evdev_at_set1_scancodes[0x80 + (scancode & 0x7f)];
+		break;
+	case 0xE1:	/* 0xE1 prefix */
+		/*
+		 * The pause/break key on the 101 keyboard produces:
+		 * E1-1D-45 E1-9D-C5
+		 * Ctrl-pause/break produces:
+		 * E0-46 E0-C6 (See above.)
+		 */
+		*state = 0;
+		if ((scancode & 0x7f) == 0x1D)
+			*state = 0x1D;
+		return (NONE);
+		/* NOT REACHED */
+	case 0x1D:	/* pause / break */
+		*state = 0;
+		if (scancode != 0x45)
+			return (NONE);
+		keycode = KEY_PAUSE;
+		break;
+	}
+
+	return (keycode);
+}
+
+void
+evdev_push_mouse_btn(struct evdev_dev *evdev, int buttons)
+{
+	size_t i;
+
+	for (i = 0; i < nitems(evdev_mouse_button_codes); i++)
+		evdev_push_event(evdev, EV_KEY, evdev_mouse_button_codes[i],
+		    (buttons & (1 << i)) != 0);
+}
+
+void
+evdev_push_leds(struct evdev_dev *evdev, int leds)
+{
+	size_t i;
+
+	/* Some drivers initialize leds before evdev */
+	if (evdev == NULL)
+		return;
+
+	for (i = 0; i < nitems(evdev_led_codes); i++)
+		evdev_push_event(evdev, EV_LED, evdev_led_codes[i],
+		    (leds & (1 << i)) != 0);
+}
+
+void
+evdev_push_repeats(struct evdev_dev *evdev, keyboard_t *kbd)
+{
+	/* Some drivers initialize typematics before evdev */
+	if (evdev == NULL)
+		return;
+
+	evdev_push_event(evdev, EV_REP, REP_DELAY, kbd->kb_delay1);
+	evdev_push_event(evdev, EV_REP, REP_PERIOD, kbd->kb_delay2);
+}
+
+void
+evdev_ev_kbd_event(struct evdev_dev *evdev, void *softc, uint16_t type,
+    uint16_t code, int32_t value)
+{
+        keyboard_t *kbd = (keyboard_t *)softc;
+	int delay[2], leds, oleds;
+	size_t i;
+
+	if (type == EV_LED) {
+		leds = oleds = KBD_LED_VAL(kbd);
+		for (i = 0; i < nitems(evdev_led_codes); i++) {
+			if (evdev_led_codes[i] == code) {
+				if (value)
+					leds |= 1 << i;
+				else
+					leds &= ~(1 << i);
+				if (leds != oleds)
+					kbdd_ioctl(kbd, KDSETLED,
+					    (caddr_t)&leds);
+				break;
+			}
+		}
+	} else if (type == EV_REP && code == REP_DELAY) {
+		delay[0] = value;
+		delay[1] = kbd->kb_delay2;
+		kbdd_ioctl(kbd, KDSETREPEAT, (caddr_t)delay);
+	} else if (type == EV_REP && code == REP_PERIOD) {
+		delay[0] = kbd->kb_delay1;
+		delay[1] = value;
+		kbdd_ioctl(kbd, KDSETREPEAT, (caddr_t)delay);
+	}
+}

--- a/sys/dev/evdev/input.h
+++ b/sys/dev/evdev/input.h
@@ -1,0 +1,1058 @@
+/*-
+ * Copyright (c) 2016 Oleksandr Tymoshenko <gonzo@FreeBSD.org>
+ * Copyright (c) 2015-2016 Vladimir Kondratyev <wulf@cicgroup.ru>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef	_EVDEV_INPUT_H
+#define	_EVDEV_INPUT_H
+
+#ifndef __KERNEL__
+#include <sys/time.h>
+#include <sys/ioccom.h>
+#include <sys/types.h>
+#endif
+
+struct input_event {
+	struct timeval	time;
+	uint16_t	type;
+	uint16_t	code;
+	int32_t		value;
+};
+
+#define	EV_VERSION		0x010001
+
+struct input_id {
+	uint16_t	bustype;
+	uint16_t	vendor;
+	uint16_t	product;
+	uint16_t	version;
+};
+
+struct input_absinfo {
+	int32_t		value;
+	int32_t		minimum;
+	int32_t		maximum;
+	int32_t		fuzz;
+	int32_t		flat;
+	int32_t		resolution;
+};
+
+#define	INPUT_KEYMAP_BY_INDEX	(1 << 0)
+
+struct input_keymap_entry {
+	uint8_t		flags;
+	uint8_t		len;
+	uint16_t	index;
+	uint32_t	keycode;
+	uint8_t		scancode[32];
+};
+
+#define	EVDEV_IOC_MAGIC	'E'
+#define	EVIOCGVERSION		_IOR(EVDEV_IOC_MAGIC, 0x01, int)		/* get driver version */
+#define	EVIOCGID		_IOR(EVDEV_IOC_MAGIC, 0x02, struct input_id)	/* get device ID */
+#define	EVIOCGREP		_IOR(EVDEV_IOC_MAGIC, 0x03, unsigned int[2])	/* get repeat settings */
+#define	EVIOCSREP		_IOW(EVDEV_IOC_MAGIC, 0x03, unsigned int[2])	/* set repeat settings */
+
+#define	EVIOCGKEYCODE		_IOR(EVDEV_IOC_MAGIC, 0x04, unsigned int[2])	/* get keycode */
+#define	EVIOCGKEYCODE_V2	_IOR(EVDEV_IOC_MAGIC, 0x04, struct input_keymap_entry)
+#define	EVIOCSKEYCODE		_IOW(EVDEV_IOC_MAGIC, 0x04, unsigned int[2])	/* set keycode */
+#define	EVIOCSKEYCODE_V2	_IOW(EVDEV_IOC_MAGIC, 0x04, struct input_keymap_entry)
+
+#define	EVIOCGNAME(len)		_IOC(IOC_OUT, EVDEV_IOC_MAGIC, 0x06, len)	/* get device name */
+#define	EVIOCGPHYS(len)		_IOC(IOC_OUT, EVDEV_IOC_MAGIC, 0x07, len)	/* get physical location */
+#define	EVIOCGUNIQ(len)		_IOC(IOC_OUT, EVDEV_IOC_MAGIC, 0x08, len)	/* get unique identifier */
+#define	EVIOCGPROP(len)		_IOC(IOC_OUT, EVDEV_IOC_MAGIC, 0x09, len)	/* get device properties */
+
+#define	EVIOCGMTSLOTS(len)	_IOC(IOC_INOUT,	EVDEV_IOC_MAGIC, 0x0a, len)	/* get MT slots values */
+
+#define	EVIOCGKEY(len)		_IOC(IOC_OUT, EVDEV_IOC_MAGIC, 0x18, len)	/* get global key state */
+#define	EVIOCGLED(len)		_IOC(IOC_OUT, EVDEV_IOC_MAGIC, 0x19, len)	/* get all LEDs */
+#define	EVIOCGSND(len)		_IOC(IOC_OUT, EVDEV_IOC_MAGIC, 0x1a, len)	/* get all sounds status */
+#define	EVIOCGSW(len)		_IOC(IOC_OUT, EVDEV_IOC_MAGIC, 0x1b, len)	/* get all switch states */
+
+#define	EVIOCGBIT(ev,len)	_IOC(IOC_OUT, EVDEV_IOC_MAGIC, 0x20 + (ev), len)	/* get event bits */
+#define	EVIOCGABS(abs)		_IOR(EVDEV_IOC_MAGIC, 0x40 + (abs), struct input_absinfo)	/* get abs value/limits */
+#define	EVIOCSABS(abs)		_IOW(EVDEV_IOC_MAGIC, 0xc0 + (abs), struct input_absinfo)	/* set abs value/limits */
+
+#define	EVIOCSFF		_IOC(IOC_IN, EVDEV_IOC_MAGIC, 0x80, sizeof(struct ff_effect))	/* send a force effect to a force feedback device */
+#define	EVIOCRMFF		_IOW(EVDEV_IOC_MAGIC, 0x81, int)			/* Erase a force effect */
+#define	EVIOCGEFFECTS		_IOR(EVDEV_IOC_MAGIC, 0x84, int)			/* Report number of effects playable at the same time */
+
+#define	EVIOCGRAB		_IOWINT(EVDEV_IOC_MAGIC, 0x90)			/* Grab/Release device */
+#define	EVIOCREVOKE		_IOWINT(EVDEV_IOC_MAGIC, 0x91)			/* Revoke device access */
+
+#define	EVIOCSCLOCKID		_IOW(EVDEV_IOC_MAGIC, 0xa0, int)			/* Set clockid to be used for timestamps */
+
+/*
+ * Device properties and quirks
+ */
+
+#define	INPUT_PROP_POINTER		0x00	/* needs a pointer */
+#define	INPUT_PROP_DIRECT		0x01	/* direct input devices */
+#define	INPUT_PROP_BUTTONPAD		0x02	/* has button(s) under pad */
+#define	INPUT_PROP_SEMI_MT		0x03	/* touch rectangle only */
+#define	INPUT_PROP_TOPBUTTONPAD		0x04	/* softbuttons at top of pad */
+#define	INPUT_PROP_POINTING_STICK	0x05	/* is a pointing stick */
+#define	INPUT_PROP_ACCELEROMETER	0x06	/* has accelerometer */
+
+#define	INPUT_PROP_MAX			0x1f
+#define	INPUT_PROP_CNT			(INPUT_PROP_MAX + 1)
+
+/*
+ * Event types
+ */
+
+#define	EV_SYN			0x00
+#define	EV_KEY			0x01
+#define	EV_REL			0x02
+#define	EV_ABS			0x03
+#define	EV_MSC			0x04
+#define	EV_SW			0x05
+#define	EV_LED			0x11
+#define	EV_SND			0x12
+#define	EV_REP			0x14
+#define	EV_FF			0x15
+#define	EV_PWR			0x16
+#define	EV_FF_STATUS		0x17
+#define	EV_MAX			0x1f
+#define	EV_CNT			(EV_MAX+1)
+
+/*
+ * Synchronization events.
+ */
+
+#define	SYN_REPORT		0
+#define	SYN_CONFIG		1
+#define	SYN_MT_REPORT		2
+#define	SYN_DROPPED		3
+#define	SYN_MAX			0xf
+#define	SYN_CNT			(SYN_MAX+1)
+
+/*
+ * Keys and buttons
+ */
+
+/*
+ * Abbreviations in the comments:
+ * AC - Application Control
+ * AL - Application Launch Button
+ * SC - System Control
+ */
+
+#define	KEY_RESERVED		0
+#define	KEY_ESC			1
+#define	KEY_1			2
+#define	KEY_2			3
+#define	KEY_3			4
+#define	KEY_4			5
+#define	KEY_5			6
+#define	KEY_6			7
+#define	KEY_7			8
+#define	KEY_8			9
+#define	KEY_9			10
+#define	KEY_0			11
+#define	KEY_MINUS		12
+#define	KEY_EQUAL		13
+#define	KEY_BACKSPACE		14
+#define	KEY_TAB			15
+#define	KEY_Q			16
+#define	KEY_W			17
+#define	KEY_E			18
+#define	KEY_R			19
+#define	KEY_T			20
+#define	KEY_Y			21
+#define	KEY_U			22
+#define	KEY_I			23
+#define	KEY_O			24
+#define	KEY_P			25
+#define	KEY_LEFTBRACE		26
+#define	KEY_RIGHTBRACE		27
+#define	KEY_ENTER		28
+#define	KEY_LEFTCTRL		29
+#define	KEY_A			30
+#define	KEY_S			31
+#define	KEY_D			32
+#define	KEY_F			33
+#define	KEY_G			34
+#define	KEY_H			35
+#define	KEY_J			36
+#define	KEY_K			37
+#define	KEY_L			38
+#define	KEY_SEMICOLON		39
+#define	KEY_APOSTROPHE		40
+#define	KEY_GRAVE		41
+#define	KEY_LEFTSHIFT		42
+#define	KEY_BACKSLASH		43
+#define	KEY_Z			44
+#define	KEY_X			45
+#define	KEY_C			46
+#define	KEY_V			47
+#define	KEY_B			48
+#define	KEY_N			49
+#define	KEY_M			50
+#define	KEY_COMMA		51
+#define	KEY_DOT			52
+#define	KEY_SLASH		53
+#define	KEY_RIGHTSHIFT		54
+#define	KEY_KPASTERISK		55
+#define	KEY_LEFTALT		56
+#define	KEY_SPACE		57
+#define	KEY_CAPSLOCK		58
+#define	KEY_F1			59
+#define	KEY_F2			60
+#define	KEY_F3			61
+#define	KEY_F4			62
+#define	KEY_F5			63
+#define	KEY_F6			64
+#define	KEY_F7			65
+#define	KEY_F8			66
+#define	KEY_F9			67
+#define	KEY_F10			68
+#define	KEY_NUMLOCK		69
+#define	KEY_SCROLLLOCK		70
+#define	KEY_KP7			71
+#define	KEY_KP8			72
+#define	KEY_KP9			73
+#define	KEY_KPMINUS		74
+#define	KEY_KP4			75
+#define	KEY_KP5			76
+#define	KEY_KP6			77
+#define	KEY_KPPLUS		78
+#define	KEY_KP1			79
+#define	KEY_KP2			80
+#define	KEY_KP3			81
+#define	KEY_KP0			82
+#define	KEY_KPDOT		83
+
+#define	KEY_ZENKAKUHANKAKU	85
+#define	KEY_102ND		86
+#define	KEY_F11			87
+#define	KEY_F12			88
+#define	KEY_RO			89
+#define	KEY_KATAKANA		90
+#define	KEY_HIRAGANA		91
+#define	KEY_HENKAN		92
+#define	KEY_KATAKANAHIRAGANA	93
+#define	KEY_MUHENKAN		94
+#define	KEY_KPJPCOMMA		95
+#define	KEY_KPENTER		96
+#define	KEY_RIGHTCTRL		97
+#define	KEY_KPSLASH		98
+#define	KEY_SYSRQ		99
+#define	KEY_RIGHTALT		100
+#define	KEY_LINEFEED		101
+#define	KEY_HOME		102
+#define	KEY_UP			103
+#define	KEY_PAGEUP		104
+#define	KEY_LEFT		105
+#define	KEY_RIGHT		106
+#define	KEY_END			107
+#define	KEY_DOWN		108
+#define	KEY_PAGEDOWN		109
+#define	KEY_INSERT		110
+#define	KEY_DELETE		111
+#define	KEY_MACRO		112
+#define	KEY_MUTE		113
+#define	KEY_VOLUMEDOWN		114
+#define	KEY_VOLUMEUP		115
+#define	KEY_POWER		116	/* SC System Power Down */
+#define	KEY_KPEQUAL		117
+#define	KEY_KPPLUSMINUS		118
+#define	KEY_PAUSE		119
+#define	KEY_SCALE		120	/* AL Compiz Scale (Expose) */
+
+#define	KEY_KPCOMMA		121
+#define	KEY_HANGEUL		122
+#define	KEY_HANGUEL		KEY_HANGEUL
+#define	KEY_HANJA		123
+#define	KEY_YEN			124
+#define	KEY_LEFTMETA		125
+#define	KEY_RIGHTMETA		126
+#define	KEY_COMPOSE		127
+
+#define	KEY_STOP		128	/* AC Stop */
+#define	KEY_AGAIN		129
+#define	KEY_PROPS		130	/* AC Properties */
+#define	KEY_UNDO		131	/* AC Undo */
+#define	KEY_FRONT		132
+#define	KEY_COPY		133	/* AC Copy */
+#define	KEY_OPEN		134	/* AC Open */
+#define	KEY_PASTE		135	/* AC Paste */
+#define	KEY_FIND		136	/* AC Search */
+#define	KEY_CUT			137	/* AC Cut */
+#define	KEY_HELP		138	/* AL Integrated Help Center */
+#define	KEY_MENU		139	/* Menu (show menu) */
+#define	KEY_CALC		140	/* AL Calculator */
+#define	KEY_SETUP		141
+#define	KEY_SLEEP		142	/* SC System Sleep */
+#define	KEY_WAKEUP		143	/* System Wake Up */
+#define	KEY_FILE		144	/* AL Local Machine Browser */
+#define	KEY_SENDFILE		145
+#define	KEY_DELETEFILE		146
+#define	KEY_XFER		147
+#define	KEY_PROG1		148
+#define	KEY_PROG2		149
+#define	KEY_WWW			150	/* AL Internet Browser */
+#define	KEY_MSDOS		151
+#define	KEY_COFFEE		152	/* AL Terminal Lock/Screensaver */
+#define	KEY_SCREENLOCK		KEY_COFFEE
+#define	KEY_ROTATE_DISPLAY	153	/* Display orientation for e.g. tablets */
+#define	KEY_DIRECTION		KEY_ROTATE_DISPLAY
+#define	KEY_CYCLEWINDOWS	154
+#define	KEY_MAIL		155
+#define	KEY_BOOKMARKS		156	/* AC Bookmarks */
+#define	KEY_COMPUTER		157
+#define	KEY_BACK		158	/* AC Back */
+#define	KEY_FORWARD		159	/* AC Forward */
+#define	KEY_CLOSECD		160
+#define	KEY_EJECTCD		161
+#define	KEY_EJECTCLOSECD	162
+#define	KEY_NEXTSONG		163
+#define	KEY_PLAYPAUSE		164
+#define	KEY_PREVIOUSSONG	165
+#define	KEY_STOPCD		166
+#define	KEY_RECORD		167
+#define	KEY_REWIND		168
+#define	KEY_PHONE		169	/* Media Select Telephone */
+#define	KEY_ISO			170
+#define	KEY_CONFIG		171	/* AL Consumer Control Configuration */
+#define	KEY_HOMEPAGE		172	/* AC Home */
+#define	KEY_REFRESH		173	/* AC Refresh */
+#define	KEY_EXIT		174	/* AC Exit */
+#define	KEY_MOVE		175
+#define	KEY_EDIT		176
+#define	KEY_SCROLLUP		177
+#define	KEY_SCROLLDOWN		178
+#define	KEY_KPLEFTPAREN		179
+#define	KEY_KPRIGHTPAREN	180
+#define	KEY_NEW			181	/* AC New */
+#define	KEY_REDO		182	/* AC Redo/Repeat */
+
+#define	KEY_F13			183
+#define	KEY_F14			184
+#define	KEY_F15			185
+#define	KEY_F16			186
+#define	KEY_F17			187
+#define	KEY_F18			188
+#define	KEY_F19			189
+#define	KEY_F20			190
+#define	KEY_F21			191
+#define	KEY_F22			192
+#define	KEY_F23			193
+#define	KEY_F24			194
+
+#define	KEY_PLAYCD		200
+#define	KEY_PAUSECD		201
+#define	KEY_PROG3		202
+#define	KEY_PROG4		203
+#define	KEY_DASHBOARD		204	/* AL Dashboard */
+#define	KEY_SUSPEND		205
+#define	KEY_CLOSE		206	/* AC Close */
+#define	KEY_PLAY		207
+#define	KEY_FASTFORWARD		208
+#define	KEY_BASSBOOST		209
+#define	KEY_PRINT		210	/* AC Print */
+#define	KEY_HP			211
+#define	KEY_CAMERA		212
+#define	KEY_SOUND		213
+#define	KEY_QUESTION		214
+#define	KEY_EMAIL		215
+#define	KEY_CHAT		216
+#define	KEY_SEARCH		217
+#define	KEY_CONNECT		218
+#define	KEY_FINANCE		219	/* AL Checkbook/Finance */
+#define	KEY_SPORT		220
+#define	KEY_SHOP		221
+#define	KEY_ALTERASE		222
+#define	KEY_CANCEL		223	/* AC Cancel */
+#define	KEY_BRIGHTNESSDOWN	224
+#define	KEY_BRIGHTNESSUP	225
+#define	KEY_MEDIA		226
+
+#define	KEY_SWITCHVIDEOMODE	227	/* Cycle between available video
+					   outputs (Monitor/LCD/TV-out/etc) */
+#define	KEY_KBDILLUMTOGGLE	228
+#define	KEY_KBDILLUMDOWN	229
+#define	KEY_KBDILLUMUP		230
+
+#define	KEY_SEND		231	/* AC Send */
+#define	KEY_REPLY		232	/* AC Reply */
+#define	KEY_FORWARDMAIL		233	/* AC Forward Msg */
+#define	KEY_SAVE		234	/* AC Save */
+#define	KEY_DOCUMENTS		235
+
+#define	KEY_BATTERY		236
+
+#define	KEY_BLUETOOTH		237
+#define	KEY_WLAN		238
+#define	KEY_UWB			239
+
+#define	KEY_UNKNOWN		240
+
+#define	KEY_VIDEO_NEXT		241	/* drive next video source */
+#define	KEY_VIDEO_PREV		242	/* drive previous video source */
+#define	KEY_BRIGHTNESS_CYCLE	243	/* brightness up, after max is min */
+#define	KEY_BRIGHTNESS_AUTO	244	/* Set Auto Brightness: manual
+					  brightness control is off,
+					  rely on ambient */
+#define	KEY_BRIGHTNESS_ZERO	KEY_BRIGHTNESS_AUTO
+#define	KEY_DISPLAY_OFF		245	/* display device to off state */
+
+#define	KEY_WWAN		246	/* Wireless WAN (LTE, UMTS, GSM, etc.) */
+#define	KEY_WIMAX		KEY_WWAN
+#define	KEY_RFKILL		247	/* Key that controls all radios */
+
+#define	KEY_MICMUTE		248	/* Mute / unmute the microphone */
+
+/* Code 255 is reserved for special needs of AT keyboard driver */
+
+#define	BTN_MISC		0x100
+#define	BTN_0			0x100
+#define	BTN_1			0x101
+#define	BTN_2			0x102
+#define	BTN_3			0x103
+#define	BTN_4			0x104
+#define	BTN_5			0x105
+#define	BTN_6			0x106
+#define	BTN_7			0x107
+#define	BTN_8			0x108
+#define	BTN_9			0x109
+
+#define	BTN_MOUSE		0x110
+#define	BTN_LEFT		0x110
+#define	BTN_RIGHT		0x111
+#define	BTN_MIDDLE		0x112
+#define	BTN_SIDE		0x113
+#define	BTN_EXTRA		0x114
+#define	BTN_FORWARD		0x115
+#define	BTN_BACK		0x116
+#define	BTN_TASK		0x117
+
+#define	BTN_JOYSTICK		0x120
+#define	BTN_TRIGGER		0x120
+#define	BTN_THUMB		0x121
+#define	BTN_THUMB2		0x122
+#define	BTN_TOP			0x123
+#define	BTN_TOP2		0x124
+#define	BTN_PINKIE		0x125
+#define	BTN_BASE		0x126
+#define	BTN_BASE2		0x127
+#define	BTN_BASE3		0x128
+#define	BTN_BASE4		0x129
+#define	BTN_BASE5		0x12a
+#define	BTN_BASE6		0x12b
+#define	BTN_DEAD		0x12f
+
+#define	BTN_GAMEPAD		0x130
+#define	BTN_SOUTH		0x130
+#define	BTN_A			BTN_SOUTH
+#define	BTN_EAST		0x131
+#define	BTN_B			BTN_EAST
+#define	BTN_C			0x132
+#define	BTN_NORTH		0x133
+#define	BTN_X			BTN_NORTH
+#define	BTN_WEST		0x134
+#define	BTN_Y			BTN_WEST
+#define	BTN_Z			0x135
+#define	BTN_TL			0x136
+#define	BTN_TR			0x137
+#define	BTN_TL2			0x138
+#define	BTN_TR2			0x139
+#define	BTN_SELECT		0x13a
+#define	BTN_START		0x13b
+#define	BTN_MODE		0x13c
+#define	BTN_THUMBL		0x13d
+#define	BTN_THUMBR		0x13e
+
+#define	BTN_DIGI		0x140
+#define	BTN_TOOL_PEN		0x140
+#define	BTN_TOOL_RUBBER		0x141
+#define	BTN_TOOL_BRUSH		0x142
+#define	BTN_TOOL_PENCIL		0x143
+#define	BTN_TOOL_AIRBRUSH	0x144
+#define	BTN_TOOL_FINGER		0x145
+#define	BTN_TOOL_MOUSE		0x146
+#define	BTN_TOOL_LENS		0x147
+#define	BTN_TOOL_QUINTTAP	0x148	/* Five fingers on trackpad */
+#define	BTN_TOUCH		0x14a
+#define	BTN_STYLUS		0x14b
+#define	BTN_STYLUS2		0x14c
+#define	BTN_TOOL_DOUBLETAP	0x14d
+#define	BTN_TOOL_TRIPLETAP	0x14e
+#define	BTN_TOOL_QUADTAP	0x14f	/* Four fingers on trackpad */
+
+#define	BTN_WHEEL		0x150
+#define	BTN_GEAR_DOWN		0x150
+#define	BTN_GEAR_UP		0x151
+
+#define	KEY_OK			0x160
+#define	KEY_SELECT		0x161
+#define	KEY_GOTO		0x162
+#define	KEY_CLEAR		0x163
+#define	KEY_POWER2		0x164
+#define	KEY_OPTION		0x165
+#define	KEY_INFO		0x166	/* AL OEM Features/Tips/Tutorial */
+#define	KEY_TIME		0x167
+#define	KEY_VENDOR		0x168
+#define	KEY_ARCHIVE		0x169
+#define	KEY_PROGRAM		0x16a	/* Media Select Program Guide */
+#define	KEY_CHANNEL		0x16b
+#define	KEY_FAVORITES		0x16c
+#define	KEY_EPG			0x16d
+#define	KEY_PVR			0x16e	/* Media Select Home */
+#define	KEY_MHP			0x16f
+#define	KEY_LANGUAGE		0x170
+#define	KEY_TITLE		0x171
+#define	KEY_SUBTITLE		0x172
+#define	KEY_ANGLE		0x173
+#define	KEY_ZOOM		0x174
+#define	KEY_MODE		0x175
+#define	KEY_KEYBOARD		0x176
+#define	KEY_SCREEN		0x177
+#define	KEY_PC			0x178	/* Media Select Computer */
+#define	KEY_TV			0x179	/* Media Select TV */
+#define	KEY_TV2			0x17a	/* Media Select Cable */
+#define	KEY_VCR			0x17b	/* Media Select VCR */
+#define	KEY_VCR2		0x17c	/* VCR Plus */
+#define	KEY_SAT			0x17d	/* Media Select Satellite */
+#define	KEY_SAT2		0x17e
+#define	KEY_CD			0x17f	/* Media Select CD */
+#define	KEY_TAPE		0x180	/* Media Select Tape */
+#define	KEY_RADIO		0x181
+#define	KEY_TUNER		0x182	/* Media Select Tuner */
+#define	KEY_PLAYER		0x183
+#define	KEY_TEXT		0x184
+#define	KEY_DVD			0x185	/* Media Select DVD */
+#define	KEY_AUX			0x186
+#define	KEY_MP3			0x187
+#define	KEY_AUDIO		0x188	/* AL Audio Browser */
+#define	KEY_VIDEO		0x189	/* AL Movie Browser */
+#define	KEY_DIRECTORY		0x18a
+#define	KEY_LIST		0x18b
+#define	KEY_MEMO		0x18c	/* Media Select Messages */
+#define	KEY_CALENDAR		0x18d
+#define	KEY_RED			0x18e
+#define	KEY_GREEN		0x18f
+#define	KEY_YELLOW		0x190
+#define	KEY_BLUE		0x191
+#define	KEY_CHANNELUP		0x192	/* Channel Increment */
+#define	KEY_CHANNELDOWN		0x193	/* Channel Decrement */
+#define	KEY_FIRST		0x194
+#define	KEY_LAST		0x195	/* Recall Last */
+#define	KEY_AB			0x196
+#define	KEY_NEXT		0x197
+#define	KEY_RESTART		0x198
+#define	KEY_SLOW		0x199
+#define	KEY_SHUFFLE		0x19a
+#define	KEY_BREAK		0x19b
+#define	KEY_PREVIOUS		0x19c
+#define	KEY_DIGITS		0x19d
+#define	KEY_TEEN		0x19e
+#define	KEY_TWEN		0x19f
+#define	KEY_VIDEOPHONE		0x1a0	/* Media Select Video Phone */
+#define	KEY_GAMES		0x1a1	/* Media Select Games */
+#define	KEY_ZOOMIN		0x1a2	/* AC Zoom In */
+#define	KEY_ZOOMOUT		0x1a3	/* AC Zoom Out */
+#define	KEY_ZOOMRESET		0x1a4	/* AC Zoom */
+#define	KEY_WORDPROCESSOR	0x1a5	/* AL Word Processor */
+#define	KEY_EDITOR		0x1a6	/* AL Text Editor */
+#define	KEY_SPREADSHEET		0x1a7	/* AL Spreadsheet */
+#define	KEY_GRAPHICSEDITOR	0x1a8	/* AL Graphics Editor */
+#define	KEY_PRESENTATION	0x1a9	/* AL Presentation App */
+#define	KEY_DATABASE		0x1aa	/* AL Database App */
+#define	KEY_NEWS		0x1ab	/* AL Newsreader */
+#define	KEY_VOICEMAIL		0x1ac	/* AL Voicemail */
+#define	KEY_ADDRESSBOOK		0x1ad	/* AL Contacts/Address Book */
+#define	KEY_MESSENGER		0x1ae	/* AL Instant Messaging */
+#define	KEY_DISPLAYTOGGLE	0x1af	/* Turn display (LCD) on and off */
+#define	KEY_BRIGHTNESS_TOGGLE	KEY_DISPLAYTOGGLE
+#define	KEY_SPELLCHECK		0x1b0   /* AL Spell Check */
+#define	KEY_LOGOFF		0x1b1   /* AL Logoff */
+
+#define	KEY_DOLLAR		0x1b2
+#define	KEY_EURO		0x1b3
+
+#define	KEY_FRAMEBACK		0x1b4	/* Consumer - transport controls */
+#define	KEY_FRAMEFORWARD	0x1b5
+#define	KEY_CONTEXT_MENU	0x1b6	/* GenDesc - system context menu */
+#define	KEY_MEDIA_REPEAT	0x1b7	/* Consumer - transport control */
+#define	KEY_10CHANNELSUP	0x1b8	/* 10 channels up (10+) */
+#define	KEY_10CHANNELSDOWN	0x1b9	/* 10 channels down (10-) */
+#define	KEY_IMAGES		0x1ba	/* AL Image Browser */
+
+#define	KEY_DEL_EOL		0x1c0
+#define	KEY_DEL_EOS		0x1c1
+#define	KEY_INS_LINE		0x1c2
+#define	KEY_DEL_LINE		0x1c3
+
+#define	KEY_FN			0x1d0
+#define	KEY_FN_ESC		0x1d1
+#define	KEY_FN_F1		0x1d2
+#define	KEY_FN_F2		0x1d3
+#define	KEY_FN_F3		0x1d4
+#define	KEY_FN_F4		0x1d5
+#define	KEY_FN_F5		0x1d6
+#define	KEY_FN_F6		0x1d7
+#define	KEY_FN_F7		0x1d8
+#define	KEY_FN_F8		0x1d9
+#define	KEY_FN_F9		0x1da
+#define	KEY_FN_F10		0x1db
+#define	KEY_FN_F11		0x1dc
+#define	KEY_FN_F12		0x1dd
+#define	KEY_FN_1		0x1de
+#define	KEY_FN_2		0x1df
+#define	KEY_FN_D		0x1e0
+#define	KEY_FN_E		0x1e1
+#define	KEY_FN_F		0x1e2
+#define	KEY_FN_S		0x1e3
+#define	KEY_FN_B		0x1e4
+
+#define	KEY_BRL_DOT1		0x1f1
+#define	KEY_BRL_DOT2		0x1f2
+#define	KEY_BRL_DOT3		0x1f3
+#define	KEY_BRL_DOT4		0x1f4
+#define	KEY_BRL_DOT5		0x1f5
+#define	KEY_BRL_DOT6		0x1f6
+#define	KEY_BRL_DOT7		0x1f7
+#define	KEY_BRL_DOT8		0x1f8
+#define	KEY_BRL_DOT9		0x1f9
+#define	KEY_BRL_DOT10		0x1fa
+
+#define	KEY_NUMERIC_0		0x200	/* used by phones, remote controls, */
+#define	KEY_NUMERIC_1		0x201	/* and other keypads */
+#define	KEY_NUMERIC_2		0x202
+#define	KEY_NUMERIC_3		0x203
+#define	KEY_NUMERIC_4		0x204
+#define	KEY_NUMERIC_5		0x205
+#define	KEY_NUMERIC_6		0x206
+#define	KEY_NUMERIC_7		0x207
+#define	KEY_NUMERIC_8		0x208
+#define	KEY_NUMERIC_9		0x209
+#define	KEY_NUMERIC_STAR	0x20a
+#define	KEY_NUMERIC_POUND	0x20b
+#define	KEY_NUMERIC_A		0x20c	/* Phone key A - HUT Telephony 0xb9 */
+#define	KEY_NUMERIC_B		0x20d
+#define	KEY_NUMERIC_C		0x20e
+#define	KEY_NUMERIC_D		0x20f
+
+#define	KEY_CAMERA_FOCUS	0x210
+#define	KEY_WPS_BUTTON		0x211	/* WiFi Protected Setup key */
+
+#define	KEY_TOUCHPAD_TOGGLE	0x212	/* Request switch touchpad on or off */
+#define	KEY_TOUCHPAD_ON		0x213
+#define	KEY_TOUCHPAD_OFF	0x214
+
+#define	KEY_CAMERA_ZOOMIN	0x215
+#define	KEY_CAMERA_ZOOMOUT	0x216
+#define	KEY_CAMERA_UP		0x217
+#define	KEY_CAMERA_DOWN		0x218
+#define	KEY_CAMERA_LEFT		0x219
+#define	KEY_CAMERA_RIGHT	0x21a
+
+#define	KEY_ATTENDANT_ON	0x21b
+#define	KEY_ATTENDANT_OFF	0x21c
+#define	KEY_ATTENDANT_TOGGLE	0x21d	/* Attendant call on or off */
+#define	KEY_LIGHTS_TOGGLE	0x21e	/* Reading light on or off */
+
+#define	BTN_DPAD_UP		0x220
+#define	BTN_DPAD_DOWN		0x221
+#define	BTN_DPAD_LEFT		0x222
+#define	BTN_DPAD_RIGHT		0x223
+
+#define	KEY_ALS_TOGGLE		0x230	/* Ambient light sensor */
+
+#define	KEY_BUTTONCONFIG		0x240	/* AL Button Configuration */
+#define	KEY_TASKMANAGER		0x241	/* AL Task/Project Manager */
+#define	KEY_JOURNAL		0x242	/* AL Log/Journal/Timecard */
+#define	KEY_CONTROLPANEL		0x243	/* AL Control Panel */
+#define	KEY_APPSELECT		0x244	/* AL Select Task/Application */
+#define	KEY_SCREENSAVER		0x245	/* AL Screen Saver */
+#define	KEY_VOICECOMMAND		0x246	/* Listening Voice Command */
+
+#define	KEY_BRIGHTNESS_MIN		0x250	/* Set Brightness to Minimum */
+#define	KEY_BRIGHTNESS_MAX		0x251	/* Set Brightness to Maximum */
+
+#define	KEY_KBDINPUTASSIST_PREV		0x260
+#define	KEY_KBDINPUTASSIST_NEXT		0x261
+#define	KEY_KBDINPUTASSIST_PREVGROUP		0x262
+#define	KEY_KBDINPUTASSIST_NEXTGROUP		0x263
+#define	KEY_KBDINPUTASSIST_ACCEPT		0x264
+#define	KEY_KBDINPUTASSIST_CANCEL		0x265
+
+#define	BTN_TRIGGER_HAPPY		0x2c0
+#define	BTN_TRIGGER_HAPPY1		0x2c0
+#define	BTN_TRIGGER_HAPPY2		0x2c1
+#define	BTN_TRIGGER_HAPPY3		0x2c2
+#define	BTN_TRIGGER_HAPPY4		0x2c3
+#define	BTN_TRIGGER_HAPPY5		0x2c4
+#define	BTN_TRIGGER_HAPPY6		0x2c5
+#define	BTN_TRIGGER_HAPPY7		0x2c6
+#define	BTN_TRIGGER_HAPPY8		0x2c7
+#define	BTN_TRIGGER_HAPPY9		0x2c8
+#define	BTN_TRIGGER_HAPPY10		0x2c9
+#define	BTN_TRIGGER_HAPPY11		0x2ca
+#define	BTN_TRIGGER_HAPPY12		0x2cb
+#define	BTN_TRIGGER_HAPPY13		0x2cc
+#define	BTN_TRIGGER_HAPPY14		0x2cd
+#define	BTN_TRIGGER_HAPPY15		0x2ce
+#define	BTN_TRIGGER_HAPPY16		0x2cf
+#define	BTN_TRIGGER_HAPPY17		0x2d0
+#define	BTN_TRIGGER_HAPPY18		0x2d1
+#define	BTN_TRIGGER_HAPPY19		0x2d2
+#define	BTN_TRIGGER_HAPPY20		0x2d3
+#define	BTN_TRIGGER_HAPPY21		0x2d4
+#define	BTN_TRIGGER_HAPPY22		0x2d5
+#define	BTN_TRIGGER_HAPPY23		0x2d6
+#define	BTN_TRIGGER_HAPPY24		0x2d7
+#define	BTN_TRIGGER_HAPPY25		0x2d8
+#define	BTN_TRIGGER_HAPPY26		0x2d9
+#define	BTN_TRIGGER_HAPPY27		0x2da
+#define	BTN_TRIGGER_HAPPY28		0x2db
+#define	BTN_TRIGGER_HAPPY29		0x2dc
+#define	BTN_TRIGGER_HAPPY30		0x2dd
+#define	BTN_TRIGGER_HAPPY31		0x2de
+#define	BTN_TRIGGER_HAPPY32		0x2df
+#define	BTN_TRIGGER_HAPPY33		0x2e0
+#define	BTN_TRIGGER_HAPPY34		0x2e1
+#define	BTN_TRIGGER_HAPPY35		0x2e2
+#define	BTN_TRIGGER_HAPPY36		0x2e3
+#define	BTN_TRIGGER_HAPPY37		0x2e4
+#define	BTN_TRIGGER_HAPPY38		0x2e5
+#define	BTN_TRIGGER_HAPPY39		0x2e6
+#define	BTN_TRIGGER_HAPPY40		0x2e7
+
+/* We avoid low common keys in module aliases so they don't get huge. */
+#define	KEY_MIN_INTERESTING	KEY_MUTE
+#define	KEY_MAX			0x2ff
+#define	KEY_CNT			(KEY_MAX+1)
+
+/*
+ * Relative axes
+ */
+
+#define	REL_X			0x00
+#define	REL_Y			0x01
+#define	REL_Z			0x02
+#define	REL_RX			0x03
+#define	REL_RY			0x04
+#define	REL_RZ			0x05
+#define	REL_HWHEEL		0x06
+#define	REL_DIAL		0x07
+#define	REL_WHEEL		0x08
+#define	REL_MISC		0x09
+#define	REL_MAX			0x0f
+#define	REL_CNT			(REL_MAX+1)
+
+/*
+ * Absolute axes
+ */
+
+#define	ABS_X			0x00
+#define	ABS_Y			0x01
+#define	ABS_Z			0x02
+#define	ABS_RX			0x03
+#define	ABS_RY			0x04
+#define	ABS_RZ			0x05
+#define	ABS_THROTTLE		0x06
+#define	ABS_RUDDER		0x07
+#define	ABS_WHEEL		0x08
+#define	ABS_GAS			0x09
+#define	ABS_BRAKE		0x0a
+#define	ABS_HAT0X		0x10
+#define	ABS_HAT0Y		0x11
+#define	ABS_HAT1X		0x12
+#define	ABS_HAT1Y		0x13
+#define	ABS_HAT2X		0x14
+#define	ABS_HAT2Y		0x15
+#define	ABS_HAT3X		0x16
+#define	ABS_HAT3Y		0x17
+#define	ABS_PRESSURE		0x18
+#define	ABS_DISTANCE		0x19
+#define	ABS_TILT_X		0x1a
+#define	ABS_TILT_Y		0x1b
+#define	ABS_TOOL_WIDTH		0x1c
+
+#define	ABS_VOLUME		0x20
+
+#define	ABS_MISC		0x28
+
+#define	ABS_MT_SLOT		0x2f	/* MT slot being modified */
+#define	ABS_MT_TOUCH_MAJOR	0x30	/* Major axis of touching ellipse */
+#define	ABS_MT_TOUCH_MINOR	0x31	/* Minor axis (omit if circular) */
+#define	ABS_MT_WIDTH_MAJOR	0x32	/* Major axis of approaching ellipse */
+#define	ABS_MT_WIDTH_MINOR	0x33	/* Minor axis (omit if circular) */
+#define	ABS_MT_ORIENTATION	0x34	/* Ellipse orientation */
+#define	ABS_MT_POSITION_X	0x35	/* Center X touch position */
+#define	ABS_MT_POSITION_Y	0x36	/* Center Y touch position */
+#define	ABS_MT_TOOL_TYPE	0x37	/* Type of touching device */
+#define	ABS_MT_BLOB_ID		0x38	/* Group a set of packets as a blob */
+#define	ABS_MT_TRACKING_ID	0x39	/* Unique ID of initiated contact */
+#define	ABS_MT_PRESSURE		0x3a	/* Pressure on contact area */
+#define	ABS_MT_DISTANCE		0x3b	/* Contact hover distance */
+#define	ABS_MT_TOOL_X		0x3c	/* Center X tool position */
+#define	ABS_MT_TOOL_Y		0x3d	/* Center Y tool position */
+
+
+#define	ABS_MAX			0x3f
+#define	ABS_CNT			(ABS_MAX+1)
+
+/*
+ * Switch events
+ */
+
+#define	SW_LID			0x00  /* set = lid shut */
+#define	SW_TABLET_MODE		0x01  /* set = tablet mode */
+#define	SW_HEADPHONE_INSERT	0x02  /* set = inserted */
+#define	SW_RFKILL_ALL		0x03  /* rfkill master switch, type "any"
+					 set = radio enabled */
+#define	SW_RADIO		SW_RFKILL_ALL	/* deprecated */
+#define	SW_MICROPHONE_INSERT	0x04  /* set = inserted */
+#define	SW_DOCK			0x05  /* set = plugged into dock */
+#define	SW_LINEOUT_INSERT	0x06  /* set = inserted */
+#define	SW_JACK_PHYSICAL_INSERT 0x07  /* set = mechanical switch set */
+#define	SW_VIDEOOUT_INSERT	0x08  /* set = inserted */
+#define	SW_CAMERA_LENS_COVER	0x09  /* set = lens covered */
+#define	SW_KEYPAD_SLIDE		0x0a  /* set = keypad slide out */
+#define	SW_FRONT_PROXIMITY	0x0b  /* set = front proximity sensor active */
+#define	SW_ROTATE_LOCK		0x0c  /* set = rotate locked/disabled */
+#define	SW_LINEIN_INSERT	0x0d  /* set = inserted */
+#define	SW_MUTE_DEVICE		0x0e  /* set = device disabled */
+#define	SW_MAX			0x0f
+#define	SW_CNT			(SW_MAX+1)
+
+/*
+ * Misc events
+ */
+
+#define	MSC_SERIAL		0x00
+#define	MSC_PULSELED		0x01
+#define	MSC_GESTURE		0x02
+#define	MSC_RAW			0x03
+#define	MSC_SCAN		0x04
+#define	MSC_TIMESTAMP		0x05
+#define	MSC_MAX			0x07
+#define	MSC_CNT			(MSC_MAX+1)
+
+/*
+ * LEDs
+ */
+
+#define	LED_NUML		0x00
+#define	LED_CAPSL		0x01
+#define	LED_SCROLLL		0x02
+#define	LED_COMPOSE		0x03
+#define	LED_KANA		0x04
+#define	LED_SLEEP		0x05
+#define	LED_SUSPEND		0x06
+#define	LED_MUTE		0x07
+#define	LED_MISC		0x08
+#define	LED_MAIL		0x09
+#define	LED_CHARGING		0x0a
+#define	LED_MAX			0x0f
+#define	LED_CNT			(LED_MAX+1)
+
+/*
+ * Autorepeat values
+ */
+
+#define	REP_DELAY		0x00
+#define	REP_PERIOD		0x01
+#define	REP_MAX			0x01
+#define	REP_CNT			(REP_MAX+1)
+
+/*
+ * Sounds
+ */
+
+#define	SND_CLICK		0x00
+#define	SND_BELL		0x01
+#define	SND_TONE		0x02
+#define	SND_MAX			0x07
+#define	SND_CNT			(SND_MAX+1)
+
+/*
+ * IDs.
+ */
+
+#define	ID_BUS			0
+#define	ID_VENDOR		1
+#define	ID_PRODUCT		2
+#define	ID_VERSION		3
+
+#define	BUS_PCI			0x01
+#define	BUS_ISAPNP		0x02
+#define	BUS_USB			0x03
+#define	BUS_HIL			0x04
+#define	BUS_BLUETOOTH		0x05
+#define	BUS_VIRTUAL		0x06
+
+#define	BUS_ISA			0x10
+#define	BUS_I8042		0x11
+#define	BUS_XTKBD		0x12
+#define	BUS_RS232		0x13
+#define	BUS_GAMEPORT		0x14
+#define	BUS_PARPORT		0x15
+#define	BUS_AMIGA		0x16
+#define	BUS_ADB			0x17
+#define	BUS_I2C			0x18
+#define	BUS_HOST		0x19
+#define	BUS_GSC			0x1A
+#define	BUS_ATARI		0x1B
+#define	BUS_SPI			0x1C
+
+/*
+ * MT_TOOL types
+ */
+#define	MT_TOOL_FINGER		0
+#define	MT_TOOL_PEN		1
+#define	MT_TOOL_PALM		2
+#define	MT_TOOL_MAX		2
+
+/*
+ * Values describing the status of a force-feedback effect
+ */
+#define	FF_STATUS_STOPPED	0x00
+#define	FF_STATUS_PLAYING	0x01
+#define	FF_STATUS_MAX		0x01
+
+/* scheduling info for force feedback effect */
+struct ff_replay {
+	uint16_t	length;		/* length of the effect (ms) */
+	uint16_t	delay;		/* delay before effect starts (ms) */
+};
+
+/* trigger for force feedback effect */
+struct ff_trigger {
+	uint16_t	button;		/* trigger button number */
+	uint16_t	interval;	/* delay between re-triggers */
+};
+
+/* force feedback effect envelop */
+struct ff_envelope {
+	uint16_t	attack_length;	/* duration of the attach (ms) */
+	uint16_t	attack_level;	/* level at the beginning (0x0000 - 0x7fff) */
+	uint16_t	fade_length;	/* duratin of fade (ms) */
+	uint16_t	fade_level;	/* level at the end of fade */
+};
+
+struct ff_constant_effect {
+	int16_t			level;
+	struct ff_envelope	envelope;
+};
+
+struct ff_ramp_effect {
+	int16_t			start_level;
+	int16_t			end_level;
+	struct ff_envelope	envelope;
+};
+
+struct ff_condition_effect {
+	/* maximum level when joystick moved to respective side */
+	uint16_t	right_saturation;
+
+	uint16_t	left_saturation;
+	/* how fast force grows when joystick move to the respective side */
+	int16_t		right_coeff;
+	int16_t		left_coeff;
+
+	uint16_t	deadband;	/* size of dead zone when no force is produced */
+	int16_t		center;		/* center of dead zone */
+};
+
+/*
+ * Force feedback periodic effect types
+ */
+
+#define	FF_SQUARE	0x58
+#define	FF_TRIANGLE	0x59
+#define	FF_SINE		0x5a
+#define	FF_SAW_UP	0x5b
+#define	FF_SAW_DOWN	0x5c
+#define	FF_CUSTOM	0x5d
+
+#define	FF_WAVEFORM_MIN	FF_SQUARE
+#define	FF_WAVEFORM_MAX	FF_CUSTOM
+
+struct ff_periodic_effect {
+	uint16_t		waveform;
+	uint16_t		period;		/* ms */
+	int16_t			magnitude;	/* peak */
+	int16_t			offset;		/* mean, roughly */
+	uint16_t		phase;		/* horizontal shift */
+	struct ff_envelope	envelope;
+	uint32_t		custom_len;	/* FF_CUSTOM waveform only */
+	int16_t			*custom_data;	/* FF_CUSTOM waveform only */
+};
+
+struct ff_rumble_effect {
+	uint16_t	strong_magnitude;	/* magnitude of the heavy motor */
+	uint16_t	weak_magnitude;		/* magnitude of the light motor */
+};
+
+/*
+ * Force feedback effect types
+ */
+
+#define	FF_RUMBLE	0x50
+#define	FF_PERIODIC	0x51
+#define	FF_CONSTANT	0x52
+#define	FF_SPRING	0x53
+#define	FF_FRICTION	0x54
+#define	FF_DAMPER	0x55
+#define	FF_INERTIA	0x56
+#define	FF_RAMP		0x57
+
+#define	FF_EFFECT_MIN	FF_RUMBLE
+#define	FF_EFFECT_MAX	FF_RAMP
+
+struct ff_effect {
+	uint16_t		type;
+	int16_t			id;
+	uint16_t		direction;	/* [0 .. 360) degrees -> [0 .. 0x10000) */
+	struct ff_trigger	trigger;
+	struct ff_replay	replay;
+
+	union {
+		struct ff_constant_effect	constant;
+		struct ff_ramp_effect		ramp;
+		struct ff_periodic_effect	periodic;
+		struct ff_condition_effect	condition[2]; /* One for each axis */
+		struct ff_rumble_effect		rumble;
+	} u;
+};
+
+/*
+ * force feedback device properties
+ */
+
+#define	FF_GAIN		0x60
+#define	FF_AUTOCENTER	0x61
+
+#define	FF_MAX		0x7f
+#define	FF_CNT		(FF_MAX+1)
+
+#endif /* _EVDEV_INPUT_H */

--- a/sys/dev/evdev/uinput.c
+++ b/sys/dev/evdev/uinput.c
@@ -1,0 +1,590 @@
+/*-
+ * Copyright (c) 2014 Jakub Wojciech Klama <jceel@FreeBSD.org>
+ * Copyright (c) 2015-2016 Vladimir Kondratyev <wulf@cicgroup.ru>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/param.h>
+#include <sys/fcntl.h>
+#include <sys/kernel.h>
+#include <sys/conf.h>
+#include <sys/uio.h>
+#include <sys/proc.h>
+#include <sys/poll.h>
+#include <sys/selinfo.h>
+#include <sys/malloc.h>
+
+#include <dev/evdev/input.h>
+#include <dev/evdev/uinput.h>
+#include <dev/evdev/evdev.h>
+
+#undef	DEBUG
+#ifdef DEBUG
+#define	debugf(fmt, args...)	printf("evdev: " fmt "\n", ##args);
+#else
+#define	debugf(fmt, args...)
+#endif
+
+#define	UINPUT_BUFFER_SIZE	16
+
+#define	UINPUT_LOCKQ(state)		mtx_lock(&(state)->ucs_mtx)
+#define	UINPUT_UNLOCKQ(state)		mtx_unlock(&(state)->ucs_mtx)
+#define	UINPUT_LOCKQ_ASSERT(state)	mtx_assert(&(state)->ucs_mtx, MA_OWNED)
+#define UINPUT_EMPTYQ(state) \
+    ((state)->ucs_buffer_head == (state)->ucs_buffer_tail)
+
+enum uinput_state
+{
+	UINPUT_NEW = 0,
+	UINPUT_CONFIGURED,
+	UINPUT_RUNNING
+};
+
+static evdev_event_t	uinput_ev_event;
+
+static d_open_t		uinput_open;
+static d_read_t		uinput_read;
+static d_write_t	uinput_write;
+static d_ioctl_t	uinput_ioctl;
+static d_poll_t		uinput_poll;
+static d_kqfilter_t	uinput_kqfilter;
+static void uinput_dtor(void *);
+
+static int uinput_kqread(struct knote *kn, long hint);
+static void uinput_kqdetach(struct knote *kn);
+
+static struct cdevsw uinput_cdevsw = {
+	.d_version = D_VERSION,
+	.d_open = uinput_open,
+	.d_read = uinput_read,
+	.d_write = uinput_write,
+	.d_ioctl = uinput_ioctl,
+	.d_poll = uinput_poll,
+	.d_kqfilter = uinput_kqfilter,
+	.d_name = "uinput",
+};
+
+static struct evdev_methods uinput_ev_methods = {
+	.ev_open = NULL,
+	.ev_close = NULL,
+	.ev_event = uinput_ev_event,
+};
+
+static struct filterops uinput_filterops = {
+	.f_isfd = 1,
+	.f_attach = NULL,
+	.f_detach = uinput_kqdetach,
+	.f_event = uinput_kqread,
+};
+
+struct uinput_cdev_state
+{
+	enum uinput_state	ucs_state;
+	struct evdev_dev *	ucs_evdev;
+	struct mtx		ucs_mtx;
+	size_t			ucs_buffer_head;
+	size_t			ucs_buffer_tail;
+	struct selinfo		ucs_selp;
+	bool			ucs_blocked;
+	bool			ucs_selected;
+	struct input_event      ucs_buffer[UINPUT_BUFFER_SIZE];
+};
+
+static void uinput_enqueue_event(struct uinput_cdev_state *, uint16_t,
+    uint16_t, int32_t);
+static int uinput_setup_provider(struct uinput_cdev_state *,
+    struct uinput_user_dev *);
+static int uinput_cdev_create(void);
+static void uinput_notify(struct uinput_cdev_state *);
+
+static void
+uinput_ev_event(struct evdev_dev *evdev, void *softc, uint16_t type,
+    uint16_t code, int32_t value)
+{
+	struct uinput_cdev_state *state = softc;
+
+	if (type == EV_LED)
+		evdev_push_event(evdev, type, code, value);
+
+	UINPUT_LOCKQ(state);
+	uinput_enqueue_event(state, type, code, value);
+	uinput_notify(state);
+	UINPUT_UNLOCKQ(state);
+}
+
+static void
+uinput_enqueue_event(struct uinput_cdev_state *state, uint16_t type,
+    uint16_t code, int32_t value)
+{
+	size_t head, tail;
+
+	UINPUT_LOCKQ_ASSERT(state);
+
+	head = state->ucs_buffer_head;
+	tail = (state->ucs_buffer_tail + 1) % UINPUT_BUFFER_SIZE;
+
+	microtime(&state->ucs_buffer[tail].time);
+	state->ucs_buffer[tail].type = type;
+	state->ucs_buffer[tail].code = code;
+	state->ucs_buffer[tail].value = value;
+	state->ucs_buffer_tail = tail;
+
+	/* If queue is full remove oldest event */
+	if (tail == head) {
+		debugf("state %p: buffer overflow", state);
+
+		head = (head + 1) % UINPUT_BUFFER_SIZE;
+		state->ucs_buffer_head = head;
+	}
+}
+
+static int
+uinput_open(struct cdev *dev, int oflags, int devtype, struct thread *td)
+{
+	struct uinput_cdev_state *state;
+
+	state = malloc(sizeof(struct uinput_cdev_state), M_EVDEV,
+	    M_WAITOK | M_ZERO);
+	state->ucs_evdev = evdev_alloc();
+
+	mtx_init(&state->ucs_mtx, "uinput", NULL, MTX_DEF);
+	knlist_init_mtx(&state->ucs_selp.si_note, &state->ucs_mtx);
+
+	devfs_set_cdevpriv(state, uinput_dtor);
+	return (0);
+}
+
+static void
+uinput_dtor(void *data)
+{
+	struct uinput_cdev_state *state = (struct uinput_cdev_state *)data;
+
+	if (state->ucs_state == UINPUT_RUNNING)
+		evdev_unregister(NULL, state->ucs_evdev);
+
+	evdev_free(state->ucs_evdev);
+
+	knlist_clear(&state->ucs_selp.si_note, 0);
+	seldrain(&state->ucs_selp);
+	knlist_destroy(&state->ucs_selp.si_note);
+	mtx_destroy(&state->ucs_mtx);
+	free(data, M_EVDEV);
+}
+
+static int
+uinput_read(struct cdev *dev, struct uio *uio, int ioflag)
+{
+	struct uinput_cdev_state *state;
+	struct input_event *event;
+	int remaining, ret;
+
+	debugf("uinput: read %zd bytes by thread %d", uio->uio_resid,
+	    uio->uio_td->td_tid);
+
+	ret = devfs_get_cdevpriv((void **)&state);
+	if (ret != 0)
+		return (ret);
+
+	/* Zero-sized reads are allowed for error checking */
+	if (uio->uio_resid != 0 && uio->uio_resid < sizeof(struct input_event))
+		return (EINVAL);
+
+	remaining = uio->uio_resid / sizeof(struct input_event);
+
+	UINPUT_LOCKQ(state);
+
+	if (UINPUT_EMPTYQ(state)) {
+		if (ioflag & O_NONBLOCK)
+			ret = EWOULDBLOCK;
+		else {
+			if (remaining != 0) {
+				state->ucs_blocked = true;
+				ret = mtx_sleep(state, &state->ucs_mtx,
+				    PCATCH, "uiread", 0);
+			}
+		}
+	}
+
+	while (ret == 0 && !UINPUT_EMPTYQ(state) && remaining > 0) {
+		event = &state->ucs_buffer[state->ucs_buffer_head];
+		state->ucs_buffer_head = (state->ucs_buffer_head + 1) %
+		    UINPUT_BUFFER_SIZE;
+		remaining--;
+
+		UINPUT_UNLOCKQ(state);
+		ret = uiomove(event, sizeof(struct input_event), uio);
+		UINPUT_LOCKQ(state);
+	}
+
+	UINPUT_UNLOCKQ(state);
+
+	return (ret);
+}
+
+static int
+uinput_write(struct cdev *dev, struct uio *uio, int ioflag)
+{
+	struct uinput_cdev_state *state;
+	struct uinput_user_dev userdev;
+	struct input_event event;
+	int ret = 0;
+
+	debugf("uinput: write %zd bytes by thread %d", uio->uio_resid,
+	    uio->uio_td->td_tid);
+
+	ret = devfs_get_cdevpriv((void **)&state);
+	if (ret != 0)
+		return (ret);
+
+	if (state->ucs_state != UINPUT_RUNNING) {
+		/* Process written struct uinput_user_dev */
+		if (uio->uio_resid != sizeof(struct uinput_user_dev)) {
+			debugf("write size not multiple of struct uinput_user_dev size");
+			return (EINVAL);
+		}
+
+		uiomove(&userdev, sizeof(struct uinput_user_dev), uio);
+		uinput_setup_provider(state, &userdev);
+	} else {
+		/* Process written event */
+		if (uio->uio_resid % sizeof(struct input_event) != 0) {
+			debugf("write size not multiple of struct input_event size");
+			return (EINVAL);
+		}
+
+		while (uio->uio_resid > 0) {
+			uiomove(&event, sizeof(struct input_event), uio);
+			ret = evdev_inject_event(state->ucs_evdev, event.type,
+			    event.code, event.value);
+
+			if (ret != 0)
+				return (ret);
+		}
+	}
+
+	return (0);
+}
+
+static int
+uinput_setup_dev(struct uinput_cdev_state *state, struct input_id *id,
+    char *name, uint32_t ff_effects_max)
+{
+
+	if (name[0] == 0)
+		return (EINVAL);
+
+	evdev_set_name(state->ucs_evdev, name);
+	memcpy(&state->ucs_evdev->ev_id, id, sizeof(struct input_id));
+	state->ucs_state = UINPUT_CONFIGURED;
+
+	return (0);
+}
+
+static int
+uinput_setup_provider(struct uinput_cdev_state *state,
+    struct uinput_user_dev *udev)
+{
+	struct input_absinfo absinfo;
+	int i, ret;
+
+	debugf("uinput: setup_provider called, udev=%p", udev);
+
+	ret = uinput_setup_dev(state, &udev->id, udev->name,
+	    udev->ff_effects_max);
+	if (ret)
+		return (ret);
+
+	bzero(&absinfo, sizeof(struct input_absinfo));
+	for (i = 0; i < ABS_CNT; i++) {
+		if (!bit_test(state->ucs_evdev->ev_abs_flags, i))
+			continue;
+
+		absinfo.minimum = udev->absmin[i];
+		absinfo.maximum = udev->absmax[i];
+		absinfo.fuzz = udev->absfuzz[i];
+		absinfo.flat = udev->absflat[i];
+		evdev_set_absinfo(state->ucs_evdev, i, &absinfo);
+	}
+
+	return (0);
+}
+
+static int
+uinput_poll(struct cdev *dev, int events, struct thread *td)
+{
+	struct uinput_cdev_state *state;
+	int revents = 0;
+
+	debugf("uinput: poll by thread %d", td->td_tid);
+
+	if (devfs_get_cdevpriv((void **)&state) != 0)
+		return (POLLNVAL);
+
+	/* Always allow write */
+	if (events & (POLLOUT | POLLWRNORM))
+		revents |= (events & (POLLOUT | POLLWRNORM));
+
+	if (events & (POLLIN | POLLRDNORM)) {
+		UINPUT_LOCKQ(state);
+		if (!UINPUT_EMPTYQ(state))
+			revents = events & (POLLIN | POLLRDNORM);
+		else {
+			state->ucs_selected = true;
+			selrecord(td, &state->ucs_selp);
+		}
+		UINPUT_UNLOCKQ(state);
+	}
+
+	return (revents);
+}
+
+static int
+uinput_kqfilter(struct cdev *dev, struct knote *kn)
+{
+	struct uinput_cdev_state *state;
+	int ret;
+
+	ret = devfs_get_cdevpriv((void **)&state);
+	if (ret != 0)
+		return (ret);
+
+	switch(kn->kn_filter) {
+	case EVFILT_READ:
+		kn->kn_fop = &uinput_filterops;
+		break;
+	default:
+		return(EINVAL);
+	}
+	kn->kn_hook = (caddr_t)state;
+
+	knlist_add(&state->ucs_selp.si_note, kn, 0);
+	return (0);
+}
+
+static int
+uinput_kqread(struct knote *kn, long hint)
+{
+	struct uinput_cdev_state *state;
+	int ret;
+
+	state = (struct uinput_cdev_state *)kn->kn_hook;
+
+	UINPUT_LOCKQ_ASSERT(state);
+
+	ret = !UINPUT_EMPTYQ(state);
+	return (ret);
+}
+
+static void
+uinput_kqdetach(struct knote *kn)
+{
+	struct uinput_cdev_state *state;
+
+	state = (struct uinput_cdev_state *)kn->kn_hook;
+	knlist_remove(&state->ucs_selp.si_note, kn, 0);
+}
+
+static void
+uinput_notify(struct uinput_cdev_state *state)
+{
+
+	UINPUT_LOCKQ_ASSERT(state);
+
+	if (state->ucs_blocked) {
+		state->ucs_blocked = false;
+		wakeup(state);
+	}
+	if (state->ucs_selected) {
+		state->ucs_selected = false;
+		selwakeup(&state->ucs_selp);
+	}
+	KNOTE_LOCKED(&state->ucs_selp.si_note, 0);
+}
+
+static int
+uinput_ioctl(struct cdev *dev, u_long cmd, caddr_t data, int fflag,
+    struct thread *td)
+{
+	struct uinput_cdev_state *state;
+	struct uinput_setup *us;
+	struct uinput_abs_setup *uabs;
+	int ret, len;
+	char buf[NAMELEN];
+
+	len = IOCPARM_LEN(cmd);
+
+	debugf("uinput: ioctl called: cmd=0x%08lx, data=%p", cmd, data);
+
+	ret = devfs_get_cdevpriv((void **)&state);
+	if (ret != 0)
+		return (ret);
+
+	switch (IOCBASECMD(cmd)) {
+	case UI_GET_SYSNAME(0):
+		if (state->ucs_state != UINPUT_RUNNING)
+			return (ENOENT);
+		if (len == 0)
+			return (EINVAL);
+		snprintf(data, len, "event%d", state->ucs_evdev->ev_unit);
+		return (0);
+	}
+
+	switch (cmd) {
+	case UI_DEV_CREATE:
+		if (state->ucs_state != UINPUT_CONFIGURED)
+			return (EINVAL);
+
+		evdev_set_methods(state->ucs_evdev, state, &uinput_ev_methods);
+		evdev_set_flag(state->ucs_evdev, EVDEV_FLAG_SOFTREPEAT);
+		evdev_register(NULL, state->ucs_evdev);
+		state->ucs_state = UINPUT_RUNNING;
+		return (0);
+
+	case UI_DEV_DESTROY:
+		if (state->ucs_state != UINPUT_RUNNING)
+			return (0);
+
+		evdev_unregister(NULL, state->ucs_evdev);
+		state->ucs_state = UINPUT_NEW;
+		return (0);
+
+	case UI_DEV_SETUP:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+
+		us = (struct uinput_setup *)data;
+		return (uinput_setup_dev(state, &us->id, us->name,
+		    us->ff_effects_max));
+
+	case UI_ABS_SETUP:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+
+		uabs = (struct uinput_abs_setup *)data;
+		return (evdev_support_abs(state->ucs_evdev, uabs->code,
+		    &uabs->absinfo));
+
+	case UI_SET_EVBIT:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+
+		return (evdev_support_event(state->ucs_evdev, *(int *)data));
+
+	case UI_SET_KEYBIT:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+		return (evdev_support_key(state->ucs_evdev, *(int *)data));
+
+	case UI_SET_RELBIT:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+		return (evdev_support_rel(state->ucs_evdev, *(int *)data));
+
+	case UI_SET_ABSBIT:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+		return (evdev_set_abs_bit(state->ucs_evdev, *(int *)data));
+
+	case UI_SET_MSCBIT:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+		return (evdev_support_msc(state->ucs_evdev, *(int *)data));
+
+	case UI_SET_LEDBIT:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+		return (evdev_support_led(state->ucs_evdev, *(int *)data));
+
+	case UI_SET_SNDBIT:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+		return (evdev_support_snd(state->ucs_evdev, *(int *)data));
+
+	case UI_SET_FFBIT:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+		/* Fake unsupported ioctl */
+		return (0);
+
+	case UI_SET_PHYS:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+		ret = copyinstr(*(void **)data, buf, sizeof(buf), NULL);
+		/* Linux returns EINVAL when string does not fit the buffer */
+		if (ret == ENAMETOOLONG)
+			ret = EINVAL;
+		if (ret != 0)
+			return (ret);
+		evdev_set_phys(state->ucs_evdev, buf);
+		return (0);
+
+	case UI_SET_SWBIT:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+		return (evdev_support_sw(state->ucs_evdev, *(int *)data));
+
+	case UI_SET_PROPBIT:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+		return (evdev_support_prop(state->ucs_evdev, *(int *)data));
+
+	case UI_BEGIN_FF_UPLOAD:
+	case UI_END_FF_UPLOAD:
+	case UI_BEGIN_FF_ERASE:
+	case UI_END_FF_ERASE:
+		if (state->ucs_state == UINPUT_RUNNING)
+			return (EINVAL);
+		/* Fake unsupported ioctl */
+		return (0);
+
+	case UI_GET_VERSION:
+		*(unsigned int *)data = UINPUT_VERSION;
+		return (0);
+	}
+
+	return (EINVAL);
+}
+
+static int
+uinput_cdev_create(void)
+{
+	struct make_dev_args mda;
+	struct cdev *cdev;
+
+	make_dev_args_init(&mda);
+	mda.mda_devsw = &uinput_cdevsw;
+	mda.mda_uid = UID_ROOT;
+	mda.mda_gid = GID_WHEEL;
+	mda.mda_mode = 0600;
+
+	make_dev_s(&mda, &cdev, "uinput");
+
+	return (0);
+}
+
+SYSINIT(uinput, SI_SUB_DRIVERS, SI_ORDER_MIDDLE, uinput_cdev_create, NULL);

--- a/sys/dev/evdev/uinput.h
+++ b/sys/dev/evdev/uinput.h
@@ -1,0 +1,107 @@
+/*-
+ * Copyright (c) 2016 Oleksandr Tymoshenko <gonzo@FreeBSD.org>
+ * Copyright (c) 2015-2016 Vladimir Kondratyev <wulf@cicgroup.ru>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef _EVDEV_UINPUT_H_
+#define	_EVDEV_UINPUT_H_
+
+#include <sys/types.h>
+#include <dev/evdev/input.h>
+
+#define UINPUT_VERSION		5
+#define	UINPUT_MAX_NAME_SIZE	80
+
+struct uinput_ff_upload {
+	uint32_t		request_id;
+	int32_t			retval;
+	struct ff_effect	effect;
+	struct ff_effect	old;
+};
+
+struct uinput_ff_erase {
+	uint32_t		request_id;
+	int32_t			retval;
+	uint32_t		effect_id;
+};
+
+/* ioctl */
+#define UINPUT_IOCTL_BASE	'U'
+
+#define UI_DEV_CREATE		_IO(UINPUT_IOCTL_BASE, 1)
+#define UI_DEV_DESTROY		_IO(UINPUT_IOCTL_BASE, 2)
+
+struct uinput_setup {
+	struct input_id	id;
+	char		name[UINPUT_MAX_NAME_SIZE];
+	uint32_t	ff_effects_max;
+};
+
+#define UI_DEV_SETUP _IOW(UINPUT_IOCTL_BASE, 3, struct uinput_setup)
+
+struct uinput_abs_setup {
+	uint16_t		code; /* axis code */
+	struct input_absinfo	absinfo;
+};
+
+#define UI_ABS_SETUP		_IOW(UINPUT_IOCTL_BASE, 4, struct uinput_abs_setup)
+
+#define UI_GET_SYSNAME(len)	_IOC(IOC_OUT, UINPUT_IOCTL_BASE, 44, len)
+#define UI_GET_VERSION		_IOR(UINPUT_IOCTL_BASE, 45, unsigned int)
+
+#define UI_SET_EVBIT		_IOWINT(UINPUT_IOCTL_BASE, 100)
+#define UI_SET_KEYBIT		_IOWINT(UINPUT_IOCTL_BASE, 101)
+#define UI_SET_RELBIT		_IOWINT(UINPUT_IOCTL_BASE, 102)
+#define UI_SET_ABSBIT		_IOWINT(UINPUT_IOCTL_BASE, 103)
+#define UI_SET_MSCBIT		_IOWINT(UINPUT_IOCTL_BASE, 104)
+#define UI_SET_LEDBIT		_IOWINT(UINPUT_IOCTL_BASE, 105)
+#define UI_SET_SNDBIT		_IOWINT(UINPUT_IOCTL_BASE, 106)
+#define UI_SET_FFBIT		_IOWINT(UINPUT_IOCTL_BASE, 107)
+#define UI_SET_PHYS		_IO(UINPUT_IOCTL_BASE, 108)
+#define UI_SET_SWBIT		_IOWINT(UINPUT_IOCTL_BASE, 109)
+#define UI_SET_PROPBIT		_IOWINT(UINPUT_IOCTL_BASE, 110)
+
+#define UI_BEGIN_FF_UPLOAD	_IOWR(UINPUT_IOCTL_BASE, 200, struct uinput_ff_upload)
+#define UI_END_FF_UPLOAD	_IOW(UINPUT_IOCTL_BASE, 201, struct uinput_ff_upload)
+#define UI_BEGIN_FF_ERASE	_IOWR(UINPUT_IOCTL_BASE, 202, struct uinput_ff_erase)
+#define UI_END_FF_ERASE		_IOW(UINPUT_IOCTL_BASE, 203, struct uinput_ff_erase)
+
+#define EV_UINPUT		0x0101
+#define UI_FF_UPLOAD		1
+#define UI_FF_ERASE		2
+
+struct uinput_user_dev {
+	char		name[UINPUT_MAX_NAME_SIZE];
+	struct input_id	id;
+	uint32_t	ff_effects_max;
+	int32_t		absmax[ABS_CNT];
+	int32_t		absmin[ABS_CNT];
+	int32_t		absfuzz[ABS_CNT];
+	int32_t		absflat[ABS_CNT];
+};
+
+#endif /* _EVDEV_UINPUT_H_ */

--- a/sys/dev/terasic/mtl/terasic_mtl.c
+++ b/sys/dev/terasic/mtl/terasic_mtl.c
@@ -83,6 +83,9 @@ terasic_mtl_attach(struct terasic_mtl_softc *sc)
 	error = terasic_mtl_text_attach(sc);
 	if (error)
 		goto error;
+	error = terasic_mtl_touch_attach(sc);
+	if (error)
+		goto error;
 	/*
 	 * XXXRW: Once we've attached syscons or vt, we can't detach it, so do
 	 * it last.

--- a/sys/dev/terasic/mtl/terasic_mtl.h
+++ b/sys/dev/terasic/mtl/terasic_mtl.h
@@ -33,6 +33,16 @@
 #ifndef _DEV_TERASIC_MTL_H_
 #define	_DEV_TERASIC_MTL_H_
 
+struct terasic_mtl_touch_state
+{
+	int x1;
+	int y1;
+	int x2;
+	int y2;
+	uint16_t gesture;
+	uint32_t touchpoints;
+};
+
 #include "opt_syscons.h"
 
 struct terasic_mtl_softc {
@@ -81,6 +91,14 @@ struct terasic_mtl_softc {
 	struct resource	*mtl_text_res;
 	int		 mtl_text_rid;
 	uint16_t	*mtl_text_soft;
+
+	/*
+	 * evdev device
+	 */
+	struct evdev_dev *mtl_evdev;
+	struct terasic_mtl_touch_state mtl_evdev_state;
+	struct callout	mtl_evdev_callout;
+	bool		mtl_evdev_opened;
 
 	/*
 	 * Framebuffer hookup for vt(4).
@@ -171,6 +189,35 @@ struct terasic_mtl_softc {
 #define	TERASIC_MTL_ALPHA_OPAQUE	255
 
 /*
+ * Driver-recognized gestures.
+ */
+
+#define	TSG_NONE	0x00
+#define	TSG_NORTH	0x10
+#define	TSG_NORTHEAST	0x12
+#define	TSG_EAST	0x14
+#define	TSG_SOUTHEAST	0x16
+#define	TSG_SOUTH	0x18
+#define	TSG_SOUTHWEST	0x1A
+#define	TSG_WEST	0x1C
+#define	TSG_NORTHWEST	0x1E
+#define	TSG_ROTATE_CW	0x28	/* Clockwise */
+#define	TSG_ROTATE_CCW	0x29	/* Counter Clockwise */
+#define	TSG_CLICK	0x20
+#define	TSG_DCLICK	0x22	/* Double Click */
+#define	TSG2_NORTH	0x30
+#define	TSG2_NORTHEAST	0x32
+#define	TSG2_EAST	0x34
+#define	TSG2_SOUTHEAST	0x36
+#define	TSG2_SOUTH	0x38
+#define	TSG2_SOUTHWEST	0x3A
+#define	TSG2_WEST	0x3C
+#define	TSG2_NORTHWEST	0x3E
+#define	TSG2_CLICK	0x40
+#define	TSG2_ZOOM_IN	0x48
+#define	TSG2_ZOOM_OUT	0x49
+
+/*
  * Driver setup routines from the bus attachment/teardown.
  */
 int	terasic_mtl_attach(struct terasic_mtl_softc *sc);
@@ -191,6 +238,8 @@ int	terasic_mtl_syscons_attach(struct terasic_mtl_softc *sc);
 void	terasic_mtl_syscons_detach(struct terasic_mtl_softc *sc);
 int	terasic_mtl_text_attach(struct terasic_mtl_softc *sc);
 void	terasic_mtl_text_detach(struct terasic_mtl_softc *sc);
+int	terasic_mtl_touch_attach(struct terasic_mtl_softc *sc);
+void	terasic_mtl_touch_detach(struct terasic_mtl_softc *sc);
 
 /*
  * Control register I/O routines.

--- a/sys/dev/terasic/mtl/terasic_mtl_touch.c
+++ b/sys/dev/terasic/mtl/terasic_mtl_touch.c
@@ -1,0 +1,251 @@
+
+/*-
+ * Copyright (c) 2014 Jakub Wojciech Klama <jceel@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/param.h>
+#include <sys/bus.h>
+#include <sys/condvar.h>
+#include <sys/conf.h>
+#include <sys/endian.h>
+#include <sys/kernel.h>
+#include <sys/fbio.h>				/* video_adapter_t */
+#include <sys/lock.h>
+#include <sys/malloc.h>
+#include <sys/module.h>
+#include <sys/mutex.h>
+#include <sys/rman.h>
+#include <sys/systm.h>
+
+#include <machine/bus.h>
+
+#include <dev/evdev/evdev.h>
+#include <dev/evdev/input.h>
+
+#include <dev/terasic/mtl/terasic_mtl.h>
+
+static void terasic_mtl_touch_intr(void *);
+static evdev_open_t terasic_mtl_touch_open;
+static evdev_close_t terasic_mtl_touch_close;
+
+struct evdev_methods terasic_mtl_ev_methods = {
+	.ev_open = &terasic_mtl_touch_open,
+	.ev_close = &terasic_mtl_touch_close,
+};
+
+
+static uint16_t terasic_mtl_gestures[256] = {
+	/* Single finger gestures */
+	[TSG_NONE] = KEY_RESERVED,
+	[TSG_NORTH] = BTN_NORTH,
+	[TSG_EAST] = BTN_EAST,
+	[TSG_WEST] = BTN_WEST,
+	[TSG_SOUTH] = BTN_SOUTH,
+	[TSG_CLICK] = BTN_TOUCH,
+	[TSG_DCLICK] = BTN_TOUCH,
+	[TSG_ROTATE_CW] = BTN_1,
+	[TSG_ROTATE_CCW] = BTN_2,
+	/* Two finger gestures */
+	[TSG2_NORTH] = BTN_NORTH,
+	[TSG2_EAST] = BTN_EAST,
+	[TSG2_WEST] = BTN_WEST,
+	[TSG2_SOUTH] = BTN_SOUTH,
+	[TSG2_CLICK] = BTN_TOOL_DOUBLETAP,
+	[TSG2_ZOOM_IN] = KEY_ZOOMIN,
+	[TSG2_ZOOM_OUT] = KEY_ZOOMOUT,
+};
+
+int
+terasic_mtl_touch_attach(struct terasic_mtl_softc *sc)
+{
+	struct input_absinfo absinfo;
+	sc->mtl_evdev = evdev_alloc();
+	evdev_set_name(sc->mtl_evdev, device_get_desc(sc->mtl_dev));
+	evdev_set_methods(sc->mtl_evdev, sc, &terasic_mtl_ev_methods);
+	evdev_support_event(sc->mtl_evdev, EV_SYN);
+	evdev_support_event(sc->mtl_evdev, EV_KEY);
+	evdev_support_event(sc->mtl_evdev, EV_ABS);
+	evdev_support_abs(sc->mtl_evdev, ABS_MT_POSITION_X);
+	evdev_support_abs(sc->mtl_evdev, ABS_MT_POSITION_Y);
+
+	/* Support gestures as a keys */
+	evdev_support_key(sc->mtl_evdev, BTN_TOUCH);
+	evdev_support_key(sc->mtl_evdev, BTN_TOOL_DOUBLETAP);
+	evdev_support_key(sc->mtl_evdev, BTN_NORTH);
+	evdev_support_key(sc->mtl_evdev, BTN_SOUTH);
+	evdev_support_key(sc->mtl_evdev, BTN_WEST);
+	evdev_support_key(sc->mtl_evdev, BTN_EAST);
+	evdev_support_key(sc->mtl_evdev, BTN_1);
+	evdev_support_key(sc->mtl_evdev, BTN_2);
+	evdev_support_key(sc->mtl_evdev, KEY_ZOOMIN);
+	evdev_support_key(sc->mtl_evdev, KEY_ZOOMOUT);
+
+	bzero(&absinfo, sizeof(struct input_absinfo));
+
+	/* Set X axis bounds */
+	absinfo.minimum = 0;
+	absinfo.maximum = 1024;
+	evdev_set_absinfo(sc->mtl_evdev, ABS_MT_POSITION_X, &absinfo);
+
+	/* Set Y axis bounds */
+	absinfo.minimum = 0;
+	absinfo.maximum = 512;
+	evdev_set_absinfo(sc->mtl_evdev, ABS_MT_POSITION_Y, &absinfo);
+
+	evdev_register(sc->mtl_dev, sc->mtl_evdev);
+
+	callout_init(&sc->mtl_evdev_callout, 1);
+	return (0);
+}
+
+void
+terasic_mtl_touch_detach(struct terasic_mtl_softc *sc)
+{
+
+	evdev_unregister(sc->mtl_dev, sc->mtl_evdev);
+	evdev_free(sc->mtl_evdev);
+}
+
+static int
+terasic_mtl_touch_open(struct evdev_dev *evdev, void *softc)
+{
+	struct terasic_mtl_softc *sc = (struct terasic_mtl_softc *)softc;
+
+	/* Start polling */
+	callout_reset(&sc->mtl_evdev_callout, hz / 10,
+	    terasic_mtl_touch_intr, sc);
+
+	sc->mtl_evdev_opened = true;
+	return (0);
+}
+
+static void
+terasic_mtl_touch_close(struct evdev_dev *evdev, void *softc)
+{
+	struct terasic_mtl_softc *sc = (struct terasic_mtl_softc *)softc;
+
+	/* Stop polling */
+	callout_stop(&sc->mtl_evdev_callout);
+
+	sc->mtl_evdev_opened = false;
+}
+
+static void
+terasic_mtl_touch_intr(void *arg)
+{
+	struct terasic_mtl_softc *sc = (struct terasic_mtl_softc *)arg;
+	struct terasic_mtl_touch_state *state = &sc->mtl_evdev_state;
+	int32_t x1, y1, x2, y2;
+	bool sync = false;
+
+	int tsg = le32toh(bus_read_4(sc->mtl_reg_res,
+	    TERASIC_MTL_OFF_TOUCHGESTURE));
+	int touchpoints = tsg >> 8;
+	int gesture = tsg & 0xff;
+
+	if (touchpoints == 0 || touchpoints == 0xffffff) {
+		/* 
+		 * Check if it's a release and if so, push empty
+		 * MT_SYNC event
+		 */
+		if (state->touchpoints != 0) {
+			evdev_mt_sync(sc->mtl_evdev);
+			evdev_sync(sc->mtl_evdev);
+		}
+
+		state->touchpoints = 0;
+
+		callout_reset(&sc->mtl_evdev_callout, hz / 10,
+		    terasic_mtl_touch_intr, sc);
+		return;
+	}
+
+	if (gesture != 0 && gesture != 0xff) {
+		uint16_t code = terasic_mtl_gestures[gesture];
+		if (code != KEY_RESERVED) {
+			evdev_push_event(sc->mtl_evdev, EV_KEY, code, 1);
+			sync = true;
+			state->gesture = code;
+		}
+	} else {
+		if (state->gesture != 0) {
+			/* Push a release event */
+			evdev_push_event(sc->mtl_evdev, EV_KEY, state->gesture, 0);
+			sync = true;
+			state->gesture = 0;
+		}
+	}
+
+	if (touchpoints > 0) {
+		x1 = le32toh(bus_read_4(sc->mtl_reg_res,
+		    TERASIC_MTL_OFF_TOUCHPOINT_X1));
+		y1 = le32toh(bus_read_4(sc->mtl_reg_res,
+		    TERASIC_MTL_OFF_TOUCHPOINT_Y1));
+
+		if (x1 != -1 && y1 != -1 && (x1 != state->x1) &&
+		    (y1 != state->y1)) {
+			evdev_push_event(sc->mtl_evdev, EV_ABS,
+			    ABS_MT_POSITION_X, x1);
+			evdev_push_event(sc->mtl_evdev, EV_ABS,
+			    ABS_MT_POSITION_Y, y1);
+			evdev_mt_sync(sc->mtl_evdev);
+
+			state->x1 = x1;
+			state->y1 = y1;
+			sync = true;
+		}
+	}
+
+	if (touchpoints > 1) {
+		x2 = le32toh(bus_read_4(sc->mtl_reg_res,
+		    TERASIC_MTL_OFF_TOUCHPOINT_X2));
+		y2 = le32toh(bus_read_4(sc->mtl_reg_res,
+		    TERASIC_MTL_OFF_TOUCHPOINT_Y2));
+
+		if (x2 != -1 && y2 != -1 && (x2 != state->x2) &&
+		    (y2 != state->y2)) {
+			evdev_push_event(sc->mtl_evdev, EV_ABS,
+			    ABS_MT_POSITION_X, x2);
+			evdev_push_event(sc->mtl_evdev, EV_ABS,
+			    ABS_MT_POSITION_Y, y2);
+			evdev_mt_sync(sc->mtl_evdev);
+
+			state->x2 = x2;
+			state->y2 = y2;
+			sync = true;
+		}
+	}
+
+	state->touchpoints = touchpoints;
+	
+	if (sync)
+		evdev_sync(sc->mtl_evdev);
+
+	callout_reset(&sc->mtl_evdev_callout, hz / 10,
+	    terasic_mtl_touch_intr, sc);
+}

--- a/sys/dev/usb/input/uep.c
+++ b/sys/dev/usb/input/uep.c
@@ -30,6 +30,8 @@
  *  http://home.eeti.com.tw/web20/drivers/Software%20Programming%20Guide_v2.0.pdf
  */
 
+#include "opt_evdev.h"
+
 #include <sys/param.h>
 #include <sys/bus.h>
 #include <sys/callout.h>
@@ -50,6 +52,11 @@
 #include <sys/ioccom.h>
 #include <sys/fcntl.h>
 #include <sys/tty.h>
+
+#ifdef EVDEV
+#include <dev/evdev/input.h>
+#include <dev/evdev/evdev.h>
+#endif
 
 #define USB_DEBUG_VAR uep_debug
 #include <dev/usb/usb_debug.h>
@@ -93,6 +100,11 @@ struct uep_softc {
 	u_int		pollrate;
 	u_int		state;
 #define UEP_ENABLED	0x01
+#define	UEP_EV_OPENED	0x02
+
+#ifdef EVDEV
+	struct evdev_dev *evdev;
+#endif
 
 	/* Reassembling buffer. */
 	u_char		buf[UEP_PACKET_LEN_MAX];
@@ -110,6 +122,11 @@ static usb_fifo_cmd_t	uep_stop_read;
 static usb_fifo_open_t	uep_open;
 static usb_fifo_close_t	uep_close;
 
+#ifdef EVDEV
+static evdev_open_t uep_ev_open;
+static evdev_close_t uep_ev_close;
+#endif
+
 static void uep_put_queue(struct uep_softc *, u_char *);
 
 static struct usb_fifo_methods uep_fifo_methods = {
@@ -119,6 +136,13 @@ static struct usb_fifo_methods uep_fifo_methods = {
 	.f_stop_read = &uep_stop_read,
 	.basename[0] = "uep",
 };
+
+#ifdef EVDEV
+static struct evdev_methods uep_evdev_methods = {
+	.ev_open = &uep_ev_open,
+	.ev_close = &uep_ev_close,
+};
+#endif
 
 static int
 get_pkt_len(u_char *buf)
@@ -152,6 +176,7 @@ static void
 uep_process_pkt(struct uep_softc *sc, u_char *buf)
 {
 	int32_t x, y;
+	int touch;
 
 	if ((buf[0] & 0xFE) != 0x80) {
 		DPRINTF("bad input packet format 0x%.2x\n", buf[0]);
@@ -179,10 +204,18 @@ uep_process_pkt(struct uep_softc *sc, u_char *buf)
 	 *
 	 */
 
+	touch = buf[0] & (1 << 0);
 	x = (buf[1] << 7) | buf[2];
 	y = (buf[3] << 7) | buf[4];
 
 	DPRINTFN(2, "x %u y %u\n", x, y);
+
+#ifdef EVDEV
+	evdev_push_event(sc->evdev, EV_ABS, ABS_X, x);
+	evdev_push_event(sc->evdev, EV_ABS, ABS_Y, y);
+	evdev_push_event(sc->evdev, EV_KEY, BTN_TOUCH, !!touch);
+	evdev_sync(sc->evdev);
+#endif
 
 	uep_put_queue(sc, buf);
 }
@@ -260,11 +293,17 @@ uep_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 	case USB_ST_SETUP:
 	tr_setup:
 		/* check if we can put more data into the FIFO */
-		if (usb_fifo_put_bytes_max(sc->fifo.fp[USB_FIFO_RX]) != 0) {
-			usbd_xfer_set_frame_len(xfer, 0,
-			    usbd_xfer_max_len(xfer));
-			usbd_transfer_submit(xfer);
-                }
+		if (usb_fifo_put_bytes_max(sc->fifo.fp[USB_FIFO_RX]) == 0) {
+#ifdef EVDEV
+			if ((sc->state & UEP_EV_OPENED) == 0)
+				break;
+#else
+			break;
+#endif
+		}
+
+		usbd_xfer_set_frame_len(xfer, 0, usbd_xfer_max_len(xfer));
+		usbd_transfer_submit(xfer);
 		break;
 
 	default:
@@ -315,6 +354,9 @@ uep_attach(device_t dev)
 	struct usb_attach_arg *uaa = device_get_ivars(dev);
 	struct uep_softc *sc = device_get_softc(dev);
 	int error;
+#ifdef EVDEV
+	struct input_absinfo absinfo = { 0 };
+#endif
 
 	device_set_usb_desc(dev);
 
@@ -336,6 +378,27 @@ uep_attach(device_t dev)
 		DPRINTF("usb_fifo_attach error=%s\n", usbd_errstr(error));
                 goto detach;
         }
+
+#ifdef EVDEV
+	sc->evdev = evdev_alloc();
+	evdev_set_name(sc->evdev, device_get_desc(dev));
+	evdev_set_serial(sc->evdev, "0");
+	evdev_set_methods(sc->evdev, sc, &uep_evdev_methods);
+	evdev_support_prop(sc->evdev, INPUT_PROP_DIRECT);
+	evdev_support_event(sc->evdev, EV_SYN);
+	evdev_support_event(sc->evdev, EV_ABS);
+	evdev_support_event(sc->evdev, EV_KEY);
+
+	absinfo.minimum = 0;
+	absinfo.maximum = UEP_MAX_X;
+	evdev_support_abs(sc->evdev, ABS_X, &absinfo);
+
+	absinfo.minimum = 0;
+	absinfo.maximum = UEP_MAX_Y;
+	evdev_support_abs(sc->evdev, ABS_Y, &absinfo);
+
+	evdev_register(dev, sc->evdev);
+#endif
 
 	sc->buf_len = 0;
 
@@ -422,6 +485,38 @@ uep_close(struct usb_fifo *fifo, int fflags)
 		usb_fifo_free_buffer(fifo);
 	}
 }
+
+#ifdef EVDEV
+static void
+uep_ev_close(struct evdev_dev *evdev, void *ev_softc)
+{
+	struct uep_softc *sc = (struct uep_softc *)ev_softc;
+
+	mtx_lock(&sc->mtx);
+	usbd_transfer_stop(sc->xfer[UEP_INTR_DT]);
+	mtx_unlock(&sc->mtx);
+
+	sc->state &= ~(UEP_EV_OPENED);
+}
+
+static int
+uep_ev_open(struct evdev_dev *evdev, void *ev_softc)
+{
+	struct uep_softc *sc = (struct uep_softc *)ev_softc;
+
+	mtx_lock(&sc->mtx);
+
+	usbd_transfer_stop(sc->xfer[UEP_INTR_DT]);
+	usbd_xfer_set_interval(sc->xfer[UEP_INTR_DT], 100);
+	usbd_transfer_start(sc->xfer[UEP_INTR_DT]);
+
+	mtx_unlock(&sc->mtx);
+
+	sc->state |= UEP_EV_OPENED;
+
+	return (0);
+}
+#endif
 
 static devclass_t uep_devclass;
 

--- a/sys/dev/usb/input/ukbd.c
+++ b/sys/dev/usb/input/ukbd.c
@@ -40,6 +40,7 @@ __FBSDID("$FreeBSD$");
 #include "opt_compat.h"
 #include "opt_kbd.h"
 #include "opt_ukbd.h"
+#include "opt_evdev.h"
 
 #include <sys/stdint.h>
 #include <sys/stddef.h>
@@ -72,6 +73,11 @@ __FBSDID("$FreeBSD$");
 #include <dev/usb/usb_debug.h>
 
 #include <dev/usb/quirk/usb_quirk.h>
+
+#ifdef EVDEV
+#include <dev/evdev/input.h>
+#include <dev/evdev/evdev.h>
+#endif
 
 #include <sys/ioccom.h>
 #include <sys/filio.h>
@@ -161,6 +167,9 @@ struct ukbd_softc {
 	struct usb_device *sc_udev;
 	struct usb_interface *sc_iface;
 	struct usb_xfer *sc_xfer[UKBD_N_TRANSFER];
+#ifdef EVDEV
+	struct evdev_dev *sc_evdev;
+#endif
 
 	uint32_t sc_ntime[UKBD_NKEYCODE];
 	uint32_t sc_otime[UKBD_NKEYCODE];
@@ -375,6 +384,14 @@ static device_attach_t ukbd_attach;
 static device_detach_t ukbd_detach;
 static device_resume_t ukbd_resume;
 
+#ifdef EVDEV
+static struct evdev_methods ukbd_evdev_methods = {
+	.ev_open = NULL,
+	.ev_close = NULL,
+	.ev_event = evdev_ev_kbd_event,
+};
+#endif
+
 static uint8_t
 ukbd_any_key_pressed(struct ukbd_softc *sc)
 {
@@ -402,6 +419,11 @@ ukbd_put_key(struct ukbd_softc *sc, uint32_t key)
 
 	DPRINTF("0x%02x (%d) %s\n", key, key,
 	    (key & KEY_RELEASE) ? "released" : "pressed");
+
+#ifdef EVDEV
+	evdev_push_event(sc->sc_evdev, EV_KEY, evdev_hid2key(KEY_INDEX(key)), !(key & KEY_RELEASE));
+	evdev_sync(sc->sc_evdev);
+#endif
 
 	if (sc->sc_inputs < UKBD_IN_BUF_SIZE) {
 		sc->sc_input[sc->sc_inputtail] = key;
@@ -915,6 +937,11 @@ ukbd_set_leds_callback(struct usb_xfer *xfer, usb_error_t error)
 		if (!any)
 			break;
 
+#ifdef EVDEV
+		evdev_push_leds(sc->sc_evdev, sc->sc_leds);
+		evdev_sync(sc->sc_evdev);
+#endif
+
 		/* range check output report length */
 		len = sc->sc_led_size;
 		if (len > (UKBD_BUFFER_SIZE - 1))
@@ -1181,6 +1208,9 @@ ukbd_attach(device_t dev)
 	usb_error_t err;
 	uint16_t n;
 	uint16_t hid_len;
+#ifdef EVDEV
+	int i;
+#endif
 #ifdef USB_DEBUG
 	int rate;
 #endif
@@ -1278,6 +1308,31 @@ ukbd_attach(device_t dev)
 		goto detach;
 	}
 #endif
+
+#ifdef EVDEV
+	sc->sc_evdev = evdev_alloc();
+	evdev_set_name(sc->sc_evdev, device_get_desc(dev));
+	evdev_set_serial(sc->sc_evdev, "0");
+	evdev_set_methods(sc->sc_evdev, kbd, &ukbd_evdev_methods);
+	evdev_support_event(sc->sc_evdev, EV_SYN);
+	evdev_support_event(sc->sc_evdev, EV_KEY);
+	if (sc->sc_flags & (UKBD_FLAG_NUMLOCK | UKBD_FLAG_CAPSLOCK |
+			    UKBD_FLAG_SCROLLLOCK))
+		evdev_support_event(sc->sc_evdev, EV_LED);
+	evdev_support_event(sc->sc_evdev, EV_REP);
+
+	for (i = 0x00; i <= 0xFF; i++)
+		evdev_support_key(sc->sc_evdev, evdev_hid2key(i));
+	if (sc->sc_flags & UKBD_FLAG_NUMLOCK)
+		evdev_support_led(sc->sc_evdev, LED_NUML);
+	if (sc->sc_flags & UKBD_FLAG_CAPSLOCK)
+		evdev_support_led(sc->sc_evdev, LED_CAPSL);
+	if (sc->sc_flags & UKBD_FLAG_SCROLLLOCK)
+		evdev_support_led(sc->sc_evdev, LED_SCROLLL);
+
+	evdev_register(dev, sc->sc_evdev);
+#endif
+
 	sc->sc_flags |= UKBD_FLAG_ATTACHED;
 
 	if (bootverbose) {
@@ -1345,6 +1400,14 @@ ukbd_detach(device_t dev)
 		}
 	}
 #endif
+
+#ifdef EVDEV
+	if (sc->sc_flags & UKBD_FLAG_ATTACHED) {
+		evdev_unregister(dev, sc->sc_evdev);
+		evdev_free(sc->sc_evdev);
+	}
+#endif
+
 	if (KBD_IS_CONFIGURED(&sc->sc_kbd)) {
 		error = kbd_unregister(&sc->sc_kbd);
 		if (error) {
@@ -1876,6 +1939,10 @@ ukbd_ioctl_locked(keyboard_t *kbd, u_long cmd, caddr_t arg)
 		else
 			kbd->kb_delay1 = ((int *)arg)[0];
 		kbd->kb_delay2 = ((int *)arg)[1];
+#ifdef EVDEV
+		evdev_push_repeats(sc->sc_evdev, kbd);
+		evdev_sync(sc->sc_evdev);
+#endif
 		return (0);
 
 #if defined(COMPAT_FREEBSD6) || defined(COMPAT_FREEBSD5) || \
@@ -2015,6 +2082,9 @@ ukbd_set_leds(struct ukbd_softc *sc, uint8_t leds)
 static int
 ukbd_set_typematic(keyboard_t *kbd, int code)
 {
+#ifdef EVDEV
+	struct ukbd_softc *sc = kbd->kb_data;
+#endif
 	static const int delays[] = {250, 500, 750, 1000};
 	static const int rates[] = {34, 38, 42, 46, 50, 55, 59, 63,
 		68, 76, 84, 92, 100, 110, 118, 126,
@@ -2026,6 +2096,10 @@ ukbd_set_typematic(keyboard_t *kbd, int code)
 	}
 	kbd->kb_delay1 = delays[(code >> 5) & 3];
 	kbd->kb_delay2 = rates[code & 0x1f];
+#ifdef EVDEV
+	evdev_push_repeats(sc->sc_evdev, kbd);
+	evdev_sync(sc->sc_evdev);
+#endif
 	return (0);
 }
 

--- a/sys/dev/usb/input/ums.c
+++ b/sys/dev/usb/input/ums.c
@@ -35,6 +35,8 @@ __FBSDID("$FreeBSD$");
  * HID spec: http://www.usb.org/developers/devclass_docs/HID1_11.pdf
  */
 
+#include "opt_evdev.h"
+
 #include <sys/stdint.h>
 #include <sys/stddef.h>
 #include <sys/param.h>
@@ -67,6 +69,9 @@ __FBSDID("$FreeBSD$");
 #include <dev/usb/usb_debug.h>
 
 #include <dev/usb/quirk/usb_quirk.h>
+
+#include <dev/evdev/input.h>
+#include <dev/evdev/evdev.h>
 
 #include <sys/ioccom.h>
 #include <sys/filio.h>
@@ -135,10 +140,18 @@ struct ums_softc {
 
 	int sc_pollrate;
 	int sc_fflags;
+#ifdef EVDEV
+	int sc_evflags;
+#define	UMS_EVDEV_OPENED	1
+#endif
 
 	uint8_t	sc_buttons;
 	uint8_t	sc_iid;
 	uint8_t	sc_temp[64];
+
+#ifdef EVDEV
+	struct evdev_dev *sc_evdev;
+#endif
 };
 
 static void ums_put_queue_timeout(void *__sc);
@@ -149,24 +162,38 @@ static device_probe_t ums_probe;
 static device_attach_t ums_attach;
 static device_detach_t ums_detach;
 
-static usb_fifo_cmd_t ums_start_read;
-static usb_fifo_cmd_t ums_stop_read;
-static usb_fifo_open_t ums_open;
-static usb_fifo_close_t ums_close;
-static usb_fifo_ioctl_t ums_ioctl;
+static usb_fifo_cmd_t ums_fifo_start_read;
+static usb_fifo_cmd_t ums_fifo_stop_read;
+static usb_fifo_open_t ums_fifo_open;
+static usb_fifo_close_t ums_fifo_close;
+static usb_fifo_ioctl_t ums_fifo_ioctl;
 
-static void	ums_put_queue(struct ums_softc *, int32_t, int32_t,
-		    int32_t, int32_t, int32_t);
-static int	ums_sysctl_handler_parseinfo(SYSCTL_HANDLER_ARGS);
+#ifdef EVDEV
+static evdev_open_t ums_ev_open;
+static evdev_close_t ums_ev_close;
+#endif
+
+static void ums_start_rx(struct ums_softc *);
+static void ums_stop_rx(struct ums_softc *);
+static void ums_put_queue(struct ums_softc *, int32_t, int32_t,
+    int32_t, int32_t, int32_t, int32_t);
+static int ums_sysctl_handler_parseinfo(SYSCTL_HANDLER_ARGS);
 
 static struct usb_fifo_methods ums_fifo_methods = {
-	.f_open = &ums_open,
-	.f_close = &ums_close,
-	.f_ioctl = &ums_ioctl,
-	.f_start_read = &ums_start_read,
-	.f_stop_read = &ums_stop_read,
+	.f_open = &ums_fifo_open,
+	.f_close = &ums_fifo_close,
+	.f_ioctl = &ums_fifo_ioctl,
+	.f_start_read = &ums_fifo_start_read,
+	.f_stop_read = &ums_fifo_stop_read,
 	.basename[0] = "ums",
 };
+
+#ifdef EVDEV
+static struct evdev_methods ums_evdev_methods = {
+	.ev_open = &ums_ev_open,
+	.ev_close = &ums_ev_close,
+};
+#endif
 
 static void
 ums_put_queue_timeout(void *__sc)
@@ -175,7 +202,7 @@ ums_put_queue_timeout(void *__sc)
 
 	mtx_assert(&sc->sc_mtx, MA_OWNED);
 
-	ums_put_queue(sc, 0, 0, 0, 0, 0);
+	ums_put_queue(sc, 0, 0, 0, 0, 0, 0);
 }
 
 static void
@@ -186,6 +213,7 @@ ums_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 	struct usb_page_cache *pc;
 	uint8_t *buf = sc->sc_temp;
 	int32_t buttons = 0;
+	int32_t oldbuttons = 0;
 	int32_t buttons_found = 0;
 	int32_t dw = 0;
 	int32_t dx = 0;
@@ -292,6 +320,7 @@ ums_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 			else if (dt < 0)
 				buttons |= 1UL << 4;
 
+			oldbuttons = sc->sc_status.button;
 			sc->sc_status.button = buttons;
 			sc->sc_status.dx += dx;
 			sc->sc_status.dy += dy;
@@ -318,20 +347,25 @@ ums_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				usb_callout_reset(&sc->sc_callout, hz / 20,
 				    &ums_put_queue_timeout, sc);
 			} else {
-
 				usb_callout_stop(&sc->sc_callout);
-
-				ums_put_queue(sc, dx, dy, dz, dt, buttons);
+				ums_put_queue(sc, dx, dy, dz, dt, buttons,
+				    oldbuttons);
 			}
 		}
 	case USB_ST_SETUP:
 tr_setup:
 		/* check if we can put more data into the FIFO */
-		if (usb_fifo_put_bytes_max(
-		    sc->sc_fifo.fp[USB_FIFO_RX]) != 0) {
-			usbd_xfer_set_frame_len(xfer, 0, usbd_xfer_max_len(xfer));
-			usbd_transfer_submit(xfer);
+		if (usb_fifo_put_bytes_max(sc->sc_fifo.fp[USB_FIFO_RX]) == 0) {
+#ifdef EVDEV
+			if (sc->sc_evflags == 0)
+				break;
+#else
+			break;
+#endif
 		}
+
+		usbd_xfer_set_frame_len(xfer, 0, usbd_xfer_max_len(xfer));
+		usbd_transfer_submit(xfer);
 		break;
 
 	default:			/* Error */
@@ -655,6 +689,38 @@ ums_attach(device_t dev)
 	if (err)
 		goto detach;
 
+#ifdef EVDEV
+	sc->sc_evdev = evdev_alloc();
+	evdev_set_name(sc->sc_evdev, device_get_desc(dev));
+	evdev_set_serial(sc->sc_evdev, "0");
+	evdev_set_methods(sc->sc_evdev, sc, &ums_evdev_methods);
+	evdev_support_prop(sc->sc_evdev, INPUT_PROP_POINTER);
+	evdev_support_event(sc->sc_evdev, EV_SYN);
+	evdev_support_event(sc->sc_evdev, EV_REL);
+	evdev_support_event(sc->sc_evdev, EV_KEY);
+
+	info = &sc->sc_info[0];
+
+	if (info->sc_flags & UMS_FLAG_X_AXIS)
+		evdev_support_rel(sc->sc_evdev, REL_X);
+
+	if (info->sc_flags & UMS_FLAG_Y_AXIS)
+		evdev_support_rel(sc->sc_evdev, REL_Y);
+
+	if (info->sc_flags & UMS_FLAG_Z_AXIS)
+		evdev_support_rel(sc->sc_evdev, REL_WHEEL);
+
+	if (info->sc_flags & UMS_FLAG_T_AXIS)
+		evdev_support_rel(sc->sc_evdev, REL_HWHEEL);
+
+	for (i = 0; i < info->sc_buttons; i++)
+		evdev_support_key(sc->sc_evdev, BTN_MOUSE + i);
+
+	err = evdev_register(dev, sc->sc_evdev);
+	if (err)
+		goto detach;
+#endif
+
 	SYSCTL_ADD_PROC(device_get_sysctl_ctx(dev),
 	    SYSCTL_CHILDREN(device_get_sysctl_tree(dev)),
 	    OID_AUTO, "parseinfo", CTLTYPE_STRING|CTLFLAG_RD,
@@ -680,6 +746,11 @@ ums_detach(device_t self)
 
 	usb_fifo_detach(&sc->sc_fifo);
 
+#ifdef EVDEV
+	evdev_unregister(self, sc->sc_evdev);
+	evdev_free(sc->sc_evdev);
+#endif
+
 	usbd_transfer_unsetup(sc->sc_xfer, UMS_N_TRANSFER);
 
 	usb_callout_drain(&sc->sc_callout);
@@ -690,9 +761,44 @@ ums_detach(device_t self)
 }
 
 static void
-ums_start_read(struct usb_fifo *fifo)
+ums_reset(struct ums_softc *sc)
 {
-	struct ums_softc *sc = usb_fifo_softc(fifo);
+
+	/* reset all USB mouse parameters */
+
+	if (sc->sc_buttons > MOUSE_MSC_MAXBUTTON)
+		sc->sc_hw.buttons = MOUSE_MSC_MAXBUTTON;
+	else
+		sc->sc_hw.buttons = sc->sc_buttons;
+
+	sc->sc_hw.iftype = MOUSE_IF_USB;
+	sc->sc_hw.type = MOUSE_MOUSE;
+	sc->sc_hw.model = MOUSE_MODEL_GENERIC;
+	sc->sc_hw.hwid = 0;
+
+	sc->sc_mode.protocol = MOUSE_PROTO_MSC;
+	sc->sc_mode.rate = -1;
+	sc->sc_mode.resolution = MOUSE_RES_UNKNOWN;
+	sc->sc_mode.accelfactor = 0;
+	sc->sc_mode.level = 0;
+	sc->sc_mode.packetsize = MOUSE_MSC_PACKETSIZE;
+	sc->sc_mode.syncmask[0] = MOUSE_MSC_SYNCMASK;
+	sc->sc_mode.syncmask[1] = MOUSE_MSC_SYNC;
+
+	/* reset status */
+
+	sc->sc_status.flags = 0;
+	sc->sc_status.button = 0;
+	sc->sc_status.obutton = 0;
+	sc->sc_status.dx = 0;
+	sc->sc_status.dy = 0;
+	sc->sc_status.dz = 0;
+	/* sc->sc_status.dt = 0; */
+}
+
+static void
+ums_start_rx(struct ums_softc *sc)
+{
 	int rate;
 
 	/* Check if we should override the default polling interval */
@@ -715,12 +821,26 @@ ums_start_read(struct usb_fifo *fifo)
 }
 
 static void
-ums_stop_read(struct usb_fifo *fifo)
+ums_stop_rx(struct ums_softc *sc)
+{
+	usbd_transfer_stop(sc->sc_xfer[UMS_INTR_DT]);
+	usb_callout_stop(&sc->sc_callout);
+}
+
+static void
+ums_fifo_start_read(struct usb_fifo *fifo)
 {
 	struct ums_softc *sc = usb_fifo_softc(fifo);
 
-	usbd_transfer_stop(sc->sc_xfer[UMS_INTR_DT]);
-	usb_callout_stop(&sc->sc_callout);
+	ums_start_rx(sc);
+}
+
+static void
+ums_fifo_stop_read(struct usb_fifo *fifo)
+{
+	struct ums_softc *sc = usb_fifo_softc(fifo);
+
+	ums_stop_rx(sc);
 }
 
 
@@ -731,7 +851,7 @@ ums_stop_read(struct usb_fifo *fifo)
 
 static void
 ums_put_queue(struct ums_softc *sc, int32_t dx, int32_t dy,
-    int32_t dz, int32_t dt, int32_t buttons)
+    int32_t dz, int32_t dt, int32_t buttons, int32_t oldbuttons)
 {
 	uint8_t buf[8];
 
@@ -769,6 +889,24 @@ ums_put_queue(struct ums_softc *sc, int32_t dx, int32_t dy,
 		usb_fifo_put_data_linear(sc->sc_fifo.fp[USB_FIFO_RX], buf,
 		    sc->sc_mode.packetsize, 1);
 
+#ifdef EVDEV
+		/* Push evdev event */
+		if (dx != 0 || dy != 0) {
+			evdev_push_event(sc->sc_evdev, EV_REL, REL_X, dx);
+			evdev_push_event(sc->sc_evdev, EV_REL, REL_Y, -dy);
+		}
+		if (dz != 0)
+			evdev_push_event(sc->sc_evdev, EV_REL, REL_WHEEL, -dz);
+		if (dt != 0)
+			evdev_push_event(sc->sc_evdev, EV_REL, REL_HWHEEL, dt);
+
+		evdev_push_mouse_btn(sc->sc_evdev,
+		    (buttons & ~MOUSE_STDBUTTONS) |
+		    (buttons & (1 << 2) ? MOUSE_BUTTON1DOWN : 0) |
+		    (buttons & (1 << 1) ? MOUSE_BUTTON2DOWN : 0) |
+		    (buttons & (1 << 0) ? MOUSE_BUTTON3DOWN : 0));
+		evdev_sync(sc->sc_evdev);
+#endif
 	} else {
 		DPRINTF("Buffer full, discarded packet\n");
 	}
@@ -781,8 +919,46 @@ ums_reset_buf(struct ums_softc *sc)
 	usb_fifo_reset(sc->sc_fifo.fp[USB_FIFO_RX]);
 }
 
+#ifdef EVDEV
 static int
-ums_open(struct usb_fifo *fifo, int fflags)
+ums_ev_open(struct evdev_dev *evdev, void *ev_softc)
+{
+	struct ums_softc *sc = (struct ums_softc *)ev_softc;
+
+	printf("ums_ev_open()\n");
+
+	mtx_lock(&sc->sc_mtx);
+
+	sc->sc_evflags = UMS_EVDEV_OPENED;
+
+	if (sc->sc_fflags == 0) {
+		ums_reset(sc);
+		ums_start_rx(sc);
+	}
+
+	mtx_unlock(&sc->sc_mtx);
+
+	return (0);
+}
+
+static void
+ums_ev_close(struct evdev_dev *evdev, void *ev_softc)
+{
+	struct ums_softc *sc = (struct ums_softc *)ev_softc;
+
+	mtx_lock(&sc->sc_mtx);
+
+	sc->sc_evflags = 0;
+
+	if (sc->sc_fflags == 0)
+		ums_stop_rx(sc);
+
+	mtx_unlock(&sc->sc_mtx);
+}
+#endif
+
+static int
+ums_fifo_open(struct usb_fifo *fifo, int fflags)
 {
 	struct ums_softc *sc = usb_fifo_softc(fifo);
 
@@ -793,39 +969,13 @@ ums_open(struct usb_fifo *fifo, int fflags)
 		return (EBUSY);
 
 	/* check for first open */
-	if (sc->sc_fflags == 0) {
-
-		/* reset all USB mouse parameters */
-
-		if (sc->sc_buttons > MOUSE_MSC_MAXBUTTON)
-			sc->sc_hw.buttons = MOUSE_MSC_MAXBUTTON;
-		else
-			sc->sc_hw.buttons = sc->sc_buttons;
-
-		sc->sc_hw.iftype = MOUSE_IF_USB;
-		sc->sc_hw.type = MOUSE_MOUSE;
-		sc->sc_hw.model = MOUSE_MODEL_GENERIC;
-		sc->sc_hw.hwid = 0;
-
-		sc->sc_mode.protocol = MOUSE_PROTO_MSC;
-		sc->sc_mode.rate = -1;
-		sc->sc_mode.resolution = MOUSE_RES_UNKNOWN;
-		sc->sc_mode.accelfactor = 0;
-		sc->sc_mode.level = 0;
-		sc->sc_mode.packetsize = MOUSE_MSC_PACKETSIZE;
-		sc->sc_mode.syncmask[0] = MOUSE_MSC_SYNCMASK;
-		sc->sc_mode.syncmask[1] = MOUSE_MSC_SYNC;
-
-		/* reset status */
-
-		sc->sc_status.flags = 0;
-		sc->sc_status.button = 0;
-		sc->sc_status.obutton = 0;
-		sc->sc_status.dx = 0;
-		sc->sc_status.dy = 0;
-		sc->sc_status.dz = 0;
-		/* sc->sc_status.dt = 0; */
-	}
+#ifdef EVDEV
+	if (sc->sc_fflags == 0 && sc->sc_evflags == 0)
+		ums_reset(sc);
+#else
+	if (sc->sc_fflags == 0)
+		ums_reset(sc);
+#endif
 
 	if (fflags & FREAD) {
 		/* allocate RX buffer */
@@ -840,7 +990,7 @@ ums_open(struct usb_fifo *fifo, int fflags)
 }
 
 static void
-ums_close(struct usb_fifo *fifo, int fflags)
+ums_fifo_close(struct usb_fifo *fifo, int fflags)
 {
 	struct ums_softc *sc = usb_fifo_softc(fifo);
 
@@ -853,7 +1003,7 @@ ums_close(struct usb_fifo *fifo, int fflags)
 }
 
 static int
-ums_ioctl(struct usb_fifo *fifo, u_long cmd, void *addr, int fflags)
+ums_fifo_ioctl(struct usb_fifo *fifo, u_long cmd, void *addr, int fflags)
 {
 	struct ums_softc *sc = usb_fifo_softc(fifo);
 	mousemode_t mode;

--- a/sys/dev/usb/input/utouch.c
+++ b/sys/dev/usb/input/utouch.c
@@ -1,0 +1,495 @@
+/*-
+ * Copyright (c) 2014 Jakub Wojciech Klama <jceel@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#include <sys/stdint.h>
+#include <sys/stddef.h>
+#include <sys/param.h>
+#include <sys/queue.h>
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/kernel.h>
+#include <sys/bus.h>
+#include <sys/module.h>
+#include <sys/lock.h>
+#include <sys/mutex.h>
+#include <sys/condvar.h>
+#include <sys/sysctl.h>
+#include <sys/sx.h>
+#include <sys/unistd.h>
+#include <sys/callout.h>
+#include <sys/malloc.h>
+#include <sys/priv.h>
+#include <sys/conf.h>
+#include <sys/fcntl.h>
+#include <sys/sbuf.h>
+
+#include <dev/usb/usb.h>
+#include <dev/usb/usbdi.h>
+#include <dev/usb/usbdi_util.h>
+#include <dev/usb/usbhid.h>
+#include "usbdevs.h"
+
+#define	USB_DEBUG_VAR utouch_debug
+#include <dev/usb/usb_debug.h>
+
+#include <dev/usb/quirk/usb_quirk.h>
+
+#include <dev/evdev/input.h>
+#include <dev/evdev/evdev.h>
+
+#include <sys/ioccom.h>
+#include <sys/filio.h>
+#include <sys/tty.h>
+
+enum {
+	UTOUCH_INTR_DT,
+	UTOUCH_N_TRANSFER,
+};
+
+struct utouch_softc
+{
+	device_t sc_dev;
+	struct evdev_dev *sc_evdev;
+	struct mtx sc_mtx;
+	struct usb_xfer *sc_xfer[UTOUCH_N_TRANSFER];
+	struct hid_location sc_loc_x;
+	struct hid_location sc_loc_y;
+	struct hid_location sc_loc_z;
+#define	UTOUCH_BUTTON_MAX	8
+	struct hid_location sc_loc_btn[UTOUCH_BUTTON_MAX];
+	uint8_t sc_iid;
+	uint8_t	sc_iid_x;
+	uint8_t	sc_iid_y;
+	uint8_t	sc_iid_z;
+	uint8_t	sc_iid_btn[UTOUCH_BUTTON_MAX];
+	uint8_t	sc_nbuttons;
+	uint32_t sc_flags;
+#define	UTOUCH_FLAG_X_AXIS	0x0001
+#define	UTOUCH_FLAG_Y_AXIS	0x0002
+#define	UTOUCH_FLAG_Z_AXIS	0x0004
+#define	UTOUCH_FLAG_OPENED	0x0008
+
+
+	int sc_oldx;
+	int sc_oldy;
+	int sc_oldz;
+	int sc_oldbuttons;
+
+	uint8_t	sc_temp[64];
+};
+
+
+
+static usb_callback_t utouch_intr_callback;
+
+static device_probe_t utouch_probe;
+static device_attach_t utouch_attach;
+static device_detach_t utouch_detach;
+
+static evdev_open_t utouch_ev_open;
+static evdev_close_t utouch_ev_close;
+
+static int utouch_hid_test(void *, uint16_t);
+static void utouch_hid_parse(struct utouch_softc *, const void *, uint16_t);
+static void utouch_report_event(struct utouch_softc *, int, int, int, int);
+
+static struct evdev_methods utouch_evdev_methods = {
+	.ev_open = &utouch_ev_open,
+	.ev_close = &utouch_ev_close,
+};
+
+static const struct usb_config utouch_config[UTOUCH_N_TRANSFER] = {
+
+	[UTOUCH_INTR_DT] = {
+		.type = UE_INTERRUPT,
+		.endpoint = UE_ADDR_ANY,
+		.direction = UE_DIR_IN,
+		.flags = {.pipe_bof = 1,.short_xfer_ok = 1,},
+		.bufsize = 0,	/* use wMaxPacketSize */
+		.callback = &utouch_intr_callback,
+	},
+};
+
+static int
+utouch_probe(device_t dev)
+{
+	struct usb_attach_arg *uaa = device_get_ivars(dev);
+	void *d_ptr;
+	uint16_t d_len;
+	int err;
+
+	if (uaa->usb_mode != USB_MODE_HOST)
+		return (ENXIO);
+
+	if (uaa->info.bInterfaceClass != UICLASS_HID)
+		return (ENXIO);
+
+	err = usbd_req_get_hid_desc(uaa->device, NULL,
+	    &d_ptr, &d_len, M_TEMP, uaa->info.bIfaceIndex);
+
+	if (err)
+		return (ENXIO);
+
+	if (utouch_hid_test(d_ptr, d_len))
+		err = BUS_PROBE_DEFAULT;
+	else
+		err = ENXIO;
+
+	free(d_ptr, M_TEMP);
+	return (err);
+}
+
+static int
+utouch_attach(device_t dev)
+{
+	struct usb_attach_arg *uaa = device_get_ivars(dev);
+	struct utouch_softc *sc = device_get_softc(dev);
+	struct input_absinfo absinfo = { 0 };
+	void *d_ptr = NULL;
+	uint16_t d_len;
+	int isize, i, err;
+
+	device_set_usb_desc(dev);
+	sc->sc_dev = dev;
+
+	mtx_init(&sc->sc_mtx, "utouch lock", NULL, MTX_DEF | MTX_RECURSE);
+
+	err = usbd_req_set_protocol(uaa->device, NULL,
+	    uaa->info.bIfaceIndex, 1);
+
+	err = usbd_transfer_setup(uaa->device,
+	    &uaa->info.bIfaceIndex, sc->sc_xfer, utouch_config,
+	    UTOUCH_N_TRANSFER, sc, &sc->sc_mtx);
+	if (err) 
+		goto detach;
+
+	err = usbd_req_get_hid_desc(uaa->device, NULL, &d_ptr,
+	    &d_len, M_TEMP, uaa->info.bIfaceIndex);
+	if (err)
+		goto detach;
+
+	isize = hid_report_size(d_ptr, d_len, hid_input, &sc->sc_iid);
+
+	utouch_hid_parse(sc, d_ptr, d_len);
+
+	sc->sc_evdev = evdev_alloc();
+	evdev_set_name(sc->sc_evdev, device_get_desc(dev));
+	evdev_set_serial(sc->sc_evdev, "0");
+	evdev_set_methods(sc->sc_evdev, sc, &utouch_evdev_methods);
+	evdev_support_prop(sc->sc_evdev, INPUT_PROP_DIRECT);
+	evdev_support_event(sc->sc_evdev, EV_SYN);
+	evdev_support_event(sc->sc_evdev, EV_ABS);
+	evdev_support_event(sc->sc_evdev, EV_REL);
+	evdev_support_event(sc->sc_evdev, EV_KEY);
+
+	if (sc->sc_flags & UTOUCH_FLAG_Z_AXIS)
+		evdev_support_rel(sc->sc_evdev, REL_WHEEL);
+
+	for (i = 0; i < sc->sc_nbuttons; i++)
+		evdev_support_key(sc->sc_evdev, BTN_MOUSE + i);
+
+	/* Report absolute axes information */
+	absinfo.minimum = 0;
+	absinfo.maximum = 0x7fff; /* XXX should read from HID descriptor */
+	if (sc->sc_flags & UTOUCH_FLAG_X_AXIS)
+		evdev_support_abs(sc->sc_evdev, ABS_X, &absinfo);
+	if (sc->sc_flags & UTOUCH_FLAG_Y_AXIS)
+		evdev_support_abs(sc->sc_evdev, ABS_Y, &absinfo);
+
+	err = evdev_register(dev, sc->sc_evdev);
+	if (err)
+		goto detach;
+
+	return (0);
+
+detach:
+	if (d_ptr)
+		free(d_ptr, M_TEMP);
+
+	utouch_detach(dev);
+	return (ENXIO);
+}
+
+static int
+utouch_detach(device_t dev)
+{
+	struct utouch_softc *sc = device_get_softc(dev);
+	
+	/* Stop intr transfer if running */
+	utouch_ev_close(sc->sc_evdev, sc);
+
+	evdev_unregister(dev, sc->sc_evdev);
+	evdev_free(sc->sc_evdev);
+	usbd_transfer_unsetup(sc->sc_xfer, UTOUCH_N_TRANSFER);
+	mtx_destroy(&sc->sc_mtx);
+	return (0);
+}
+
+static void
+utouch_intr_callback(struct usb_xfer *xfer, usb_error_t error)
+{
+	struct utouch_softc *sc = usbd_xfer_softc(xfer);
+	struct usb_page_cache *pc;
+	void *buf = sc->sc_temp;
+	int x, y, dz, buttons = 0, changed = 0;
+	int len, i;
+	usbd_xfer_status(xfer, &len, NULL, NULL, NULL);
+
+	switch (USB_GET_STATE(xfer)) {
+	case USB_ST_TRANSFERRED:
+		if (len == 0)
+			goto tr_setup;
+			
+		pc = usbd_xfer_get_frame(xfer, 0);
+		usbd_copy_out(pc, 0, buf, len);
+
+		if (sc->sc_flags & UTOUCH_FLAG_X_AXIS) {
+			x = hid_get_data(buf, len, &sc->sc_loc_x);
+			changed += x != sc->sc_oldx;
+		}
+
+		if (sc->sc_flags & UTOUCH_FLAG_Y_AXIS) {
+			y = hid_get_data(buf, len, &sc->sc_loc_y);
+			changed += y != sc->sc_oldy;
+		}
+
+		if (sc->sc_flags & UTOUCH_FLAG_Z_AXIS) {
+			dz = hid_get_data(buf, len, &sc->sc_loc_z);
+			changed += dz != 0;
+		}
+
+		for (i = 0; i < sc->sc_nbuttons; i++) {
+			if (hid_get_data(buf, len, &sc->sc_loc_btn[i]))
+				buttons |= (1 << i);
+		}
+
+		changed += buttons != sc->sc_oldbuttons;
+
+		if (changed) {
+			utouch_report_event(sc, x, y, dz, buttons);
+			sc->sc_oldx = x;
+			sc->sc_oldy = y;
+			sc->sc_oldbuttons = buttons;
+		}
+
+	case USB_ST_SETUP:
+tr_setup:
+		usbd_xfer_set_frame_len(xfer, 0, usbd_xfer_max_len(xfer));
+		usbd_transfer_submit(xfer);
+		break;
+	default:
+		if (error != USB_ERR_CANCELLED) {
+			/* try clear stall first */
+			usbd_xfer_set_stall(xfer);
+			goto tr_setup;
+		}
+		break;
+	}
+}
+
+static void
+utouch_ev_close(struct evdev_dev *evdev, void *ev_softc)
+{
+	struct utouch_softc *sc = (struct utouch_softc *)ev_softc;
+
+	mtx_lock(&sc->sc_mtx);
+	usbd_transfer_stop(sc->sc_xfer[UTOUCH_INTR_DT]);
+	mtx_unlock(&sc->sc_mtx);
+}
+
+static int
+utouch_ev_open(struct evdev_dev *evdev, void *ev_softc)
+{
+	struct utouch_softc *sc = (struct utouch_softc *)ev_softc;
+
+	mtx_lock(&sc->sc_mtx);
+
+	usbd_transfer_stop(sc->sc_xfer[UTOUCH_INTR_DT]);
+	usbd_xfer_set_interval(sc->sc_xfer[UTOUCH_INTR_DT], 100);
+	usbd_transfer_start(sc->sc_xfer[UTOUCH_INTR_DT]);
+
+	mtx_unlock(&sc->sc_mtx);
+
+	return (0);
+}
+
+static void
+utouch_report_event(struct utouch_softc *sc, int x, int y, int dz, int buttons)
+{
+	int i;
+
+	if (x != sc->sc_oldx || y != sc->sc_oldy) {
+		if (sc->sc_flags & UTOUCH_FLAG_X_AXIS)
+			evdev_push_event(sc->sc_evdev, EV_ABS, ABS_X, x);
+
+		if (sc->sc_flags & UTOUCH_FLAG_Y_AXIS)
+			evdev_push_event(sc->sc_evdev, EV_ABS, ABS_Y, y);
+	}
+
+	if (sc->sc_flags & UTOUCH_FLAG_Z_AXIS && dz != 0)
+		evdev_push_event(sc->sc_evdev, EV_REL, REL_WHEEL, dz);
+
+	if (buttons != sc->sc_oldbuttons) {
+		for (i = 0; i < sc->sc_nbuttons; i++) {
+			if (((buttons & (1 << i)) ^
+			    (sc->sc_oldbuttons & (1 << i))) == 0)
+				continue;
+
+			evdev_push_event(sc->sc_evdev, EV_KEY,
+			    BTN_MOUSE + i, !!(buttons & (1 << i)));
+		}
+	}
+
+	evdev_sync(sc->sc_evdev);
+
+}
+
+static int
+utouch_hid_test(void *d_ptr, uint16_t d_len)
+{
+	struct hid_data *hd;
+	struct hid_item hi;
+	int mdepth;
+	int found;
+
+	hd = hid_start_parse(d_ptr, d_len, 1 << hid_input);
+	if (hd == NULL)
+		return (0);
+
+	mdepth = 0;
+	found = 0;
+
+	while (hid_get_item(hd, &hi)) {
+		switch (hi.kind) {
+		case hid_collection:
+			if (mdepth != 0)
+				mdepth++;
+			else if (hi.collection == 1 &&
+			     hi.usage ==
+			      HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_POINTER))
+				mdepth++;
+			break;
+		case hid_endcollection:
+			if (mdepth != 0)
+				mdepth--;
+			break;
+		case hid_input:
+			if (mdepth == 0)
+				break;
+			if (hi.usage ==
+			     HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_X) &&
+			    (hi.flags & (HIO_CONST|HIO_VARIABLE|HIO_RELATIVE)) == HIO_VARIABLE)
+				found++;
+			if (hi.usage ==
+			     HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_Y) &&
+			    (hi.flags & (HIO_CONST|HIO_VARIABLE|HIO_RELATIVE)) == HIO_VARIABLE)
+				found++;
+			break;
+		default:
+			break;
+		}
+	}
+	hid_end_parse(hd);
+	return (found);
+}
+
+static void
+utouch_hid_parse(struct utouch_softc *sc, const void *buf, uint16_t len)
+{
+	uint32_t flags;
+	uint8_t i;
+
+	if (hid_locate(buf, len, HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_X),
+	    hid_input, 0, &sc->sc_loc_x, &flags, &sc->sc_iid_x)) {
+
+		if (flags & HIO_VARIABLE) {
+			sc->sc_flags |= UTOUCH_FLAG_X_AXIS;
+		}
+	}
+	if (hid_locate(buf, len, HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_Y),
+	    hid_input, 0, &sc->sc_loc_y, &flags, &sc->sc_iid_y)) {
+
+		if (flags & HIO_VARIABLE) {
+			sc->sc_flags |= UTOUCH_FLAG_Y_AXIS;
+		}
+	}
+	/* Try the wheel first as the Z activator since it's tradition. */
+	if (hid_locate(buf, len, HID_USAGE2(HUP_GENERIC_DESKTOP,
+	    HUG_WHEEL), hid_input, 0, &sc->sc_loc_z, &flags,
+	    &sc->sc_iid_z) ||
+	    hid_locate(buf, len, HID_USAGE2(HUP_GENERIC_DESKTOP,
+	    HUG_TWHEEL), hid_input, 0, &sc->sc_loc_z, &flags,
+	    &sc->sc_iid_z)) {
+		if (flags & HIO_VARIABLE)
+			sc->sc_flags |= UTOUCH_FLAG_Z_AXIS;
+	}	
+
+	/* figure out the number of buttons */
+	for (i = 0; i < UTOUCH_BUTTON_MAX; i++) {
+		if (!hid_locate(buf, len, HID_USAGE2(HUP_BUTTON, (i + 1)),
+		    hid_input, 0, &sc->sc_loc_btn[i], NULL, 
+		    &sc->sc_iid_btn[i])) {
+			break;
+		}
+	}
+
+	sc->sc_nbuttons = i;
+
+	if (i > sc->sc_nbuttons)
+		sc->sc_nbuttons = i;
+
+	if (sc->sc_flags == 0)
+		return;
+
+	/* announce information about the mouse */
+	device_printf(sc->sc_dev, "%d buttons and [%s%s%s] axes\n",
+	    (sc->sc_nbuttons),
+	    (sc->sc_flags & UTOUCH_FLAG_X_AXIS) ? "X" : "",
+	    (sc->sc_flags & UTOUCH_FLAG_Y_AXIS) ? "Y" : "",
+	    (sc->sc_flags & UTOUCH_FLAG_Z_AXIS) ? "Z" : "");
+}
+
+static devclass_t utouch_devclass;
+
+static device_method_t utouch_methods[] = {
+	DEVMETHOD(device_probe, utouch_probe),
+	DEVMETHOD(device_attach, utouch_attach),
+	DEVMETHOD(device_detach, utouch_detach),
+
+	DEVMETHOD_END
+};
+
+static driver_t utouch_driver = {
+	.name = "utouch",
+	.methods = utouch_methods,
+	.size = sizeof(struct utouch_softc),
+};
+
+DRIVER_MODULE(utouch, uhub, utouch_driver, utouch_devclass, NULL, 0);
+MODULE_DEPEND(utouch, usb, 1, 1, 1);
+MODULE_VERSION(utouch, 1);

--- a/sys/dev/usb/input/wmt.c
+++ b/sys/dev/usb/input/wmt.c
@@ -1,0 +1,910 @@
+/*-
+ * Copyright (c) 2014-2015 Vladimir Kondratyev <wulf@cicgroup.ru>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#include <sys/stdint.h>
+#include <sys/stddef.h>
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/kernel.h>
+#include <sys/bus.h>
+#include <sys/module.h>
+#include <sys/lock.h>
+#include <sys/mutex.h>
+#include <sys/sysctl.h>
+#include <sys/unistd.h>
+#include <sys/malloc.h>
+#include <sys/priv.h>
+#include <sys/conf.h>
+#include <sys/fcntl.h>
+
+#include "usbdevs.h"
+#include <dev/usb/usb.h>
+#include <dev/usb/usbdi.h>
+#include <dev/usb/usbdi_util.h>
+#include <dev/usb/usbhid.h>
+#include <dev/usb/usb_ioctl.h>
+
+#define	WMT_FIFO_ENABLE	1
+#define	USB_DEBUG_VAR wmt_debug
+#include <dev/usb/usb_debug.h>
+
+#ifdef USB_DEBUG
+static int wmt_debug = 1;
+
+static SYSCTL_NODE(_hw_usb, OID_AUTO, wmt, CTLFLAG_RW, 0,
+    "USB MSWindows 7/8 compatible multitouch Pointer Device");
+SYSCTL_INT(_hw_usb_wmt, OID_AUTO, debug, CTLFLAG_RWTUN,
+    &wmt_debug, 1, "Debug level");
+#endif
+
+#include <dev/evdev/input.h>
+#include <dev/evdev/evdev.h>
+
+#include <sys/ioccom.h>
+#include <sys/filio.h>
+#include <sys/tty.h>
+
+#define	WMT_BSIZE	1024	/* bytes, buffer size */
+#define	WMT_FRAME_NUM	50	/* bytes, frame number */
+
+enum {
+	WMT_INTR_DT,
+	WMT_N_TRANSFER,
+};
+
+enum {
+	WMT_TIP_SWITCH,
+#define	WMT_SLOT	WMT_TIP_SWITCH
+	WMT_WIDTH,
+#define	WMT_MAJOR	WMT_WIDTH
+	WMT_HEIGHT,
+#define WMT_MINOR	WMT_HEIGHT
+	WMT_TOOL_WIDTH,
+#define	WMT_TOOL_MAJOR	WMT_TOOL_WIDTH
+	WMT_TOOL_HEIGHT,
+#define WMT_TOOL_MINOR	WMT_TOOL_HEIGHT
+	WMT_ORIENTATION,
+	WMT_X,
+	WMT_Y,
+	WMT_TOOL_TYPE,
+	WMT_BLOB_ID,
+	WMT_CONTACT_ID,
+	WMT_PRESSURE,
+	WMT_CONFIDENCE,
+	WMT_TOOL_X,
+	WMT_TOOL_Y,
+	WMT_N_USAGES,
+};
+
+struct wmt_hid_map_item {
+	int32_t usage;
+	uint32_t code;
+};
+
+static const struct wmt_hid_map_item wmt_hid_map[WMT_N_USAGES] = {
+	{	/* WMT_TIP_SWITCH, WMT_SLOT */
+		.usage = HID_USAGE2(HUP_DIGITIZERS, HUD_TIP_SWITCH),
+		.code = ABS_MT_SLOT
+	}, {	/* WMT_WIDTH, WMT_MAJOR */
+		.usage = HID_USAGE2(HUP_DIGITIZERS, HUD_WIDTH),
+		.code = ABS_MT_TOUCH_MAJOR
+	}, {	/* WMT_HEIGHT, WMT_MINOR */
+		.usage = HID_USAGE2(HUP_DIGITIZERS, HUD_HEIGHT),
+		.code = ABS_MT_TOUCH_MINOR
+	}, {	/* WMT_TOOL_WIDTH, WMT_TOOL_MAJOR */
+		.usage = -1,
+		.code = ABS_MT_WIDTH_MAJOR
+	}, {	/* WMT_TOOL_HEIGHT, WMT_TOOL_MINOR */
+		.usage = -1,
+		.code = ABS_MT_WIDTH_MINOR
+	}, {	/* WMT_ORIENTATION */
+		.usage = HID_USAGE2(HUP_DIGITIZERS, HUD_HEIGHT),
+		.code = ABS_MT_ORIENTATION
+	}, {	/* WMT_X */
+		.usage = HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_X),
+		.code = ABS_MT_POSITION_X
+	}, {	/* WMT_Y */
+		.usage = HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_Y),
+		.code = ABS_MT_POSITION_Y
+	}, {	/* WMT_TOOL_TYPE */
+		.usage = -1,
+		.code = ABS_MT_TOOL_TYPE
+	}, {	/* WMT_BLOB_ID */
+		.usage = -1,
+		.code = ABS_MT_BLOB_ID
+	}, {	/* WMT_CONTACT_ID */
+		.usage = HID_USAGE2(HUP_DIGITIZERS, HUD_CONTACT_IDENTIFIER),
+		.code = ABS_MT_TRACKING_ID
+	}, {	/* WMT_PRESSURE */
+		.usage = HID_USAGE2(HUP_DIGITIZERS, HUD_TIP_PRESSURE),
+		.code = ABS_MT_PRESSURE
+	}, {	/* WMT_CONFIDENCE */
+		.usage = HID_USAGE2(HUP_DIGITIZERS, HUD_CONFIDENCE),
+		.code = ABS_MT_DISTANCE
+	}, {	/* WMT_TOOL_X */
+		.usage = HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_X),
+		.code = ABS_MT_TOOL_X
+	}, {	/* WMT_TOOL_Y */
+		.usage = HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_Y),
+		.code = ABS_MT_TOOL_Y
+	}
+};
+
+#define WMT_ABSINFO_RESET	((struct input_absinfo) { .value = INT32_MIN })
+#define WMT_ABSINFO_IS_SET(x)	((x)->value != INT32_MIN)
+
+struct wmt_softc
+{
+	device_t		dev;
+	struct evdev_dev	*evdev;
+
+#ifdef WMT_FIFO_ENABLE
+	struct usb_device	*udev;
+	struct usb_fifo_sc	fifo;
+#endif
+	struct mtx		sc_mtx;
+	struct usb_xfer		*xfer[WMT_N_TRANSFER];
+	uint32_t		isize;
+	uint32_t		fsize;
+	void			*repdesc_ptr;
+	uint16_t		repdesc_size;
+	uint8_t			iid;
+	uint8_t			fid;
+
+#ifdef WMT_FIFO_ENABLE
+	uint8_t			iface_no;
+	uint8_t			iface_index;
+#endif
+	uint32_t		flags;
+#define WMT_FLAG_TIP_SWITCH	0x0001
+#define	WMT_FLAG_OPENED		0x0002
+#define	WMT_FLAG_EV_OPENED	0x0004
+#define	WMT_FLAG_RD_STARTED	0x0008
+
+	uint8_t			report_id;
+	struct hid_location	ncontacts;
+	struct hid_location	hid_items[MAX_MT_SLOTS][WMT_N_USAGES];
+	struct input_absinfo	ai[WMT_N_USAGES];
+
+	uint8_t	buf[WMT_BSIZE] __aligned(4);
+};
+
+static usb_callback_t wmt_intr_callback;
+
+static device_probe_t	wmt_probe;
+static device_attach_t	wmt_attach;
+static device_detach_t	wmt_detach;
+
+static evdev_open_t wmt_ev_open;
+static evdev_close_t wmt_ev_close;
+
+static uint32_t wmt_hid_test(const void *, uint16_t);
+static void wmt_hid_parse(struct wmt_softc *);
+
+#ifdef WMT_FIFO_ENABLE
+static usb_fifo_cmd_t	wmt_start_read;
+static usb_fifo_cmd_t	wmt_stop_read;
+static usb_fifo_open_t	wmt_open;
+static usb_fifo_close_t	wmt_close;
+static usb_fifo_ioctl_t	wmt_ioctl;
+
+static void wmt_put_queue(struct wmt_softc *, uint8_t *, usb_size_t);
+
+static struct usb_fifo_methods wmt_fifo_methods = {
+	.f_open =	&wmt_open,
+	.f_close =	&wmt_close,
+	.f_ioctl =	&wmt_ioctl,
+	.f_start_read =	&wmt_start_read,
+	.f_stop_read =	&wmt_stop_read,
+	.basename[0] =	"wmt",
+};
+#endif
+
+static struct evdev_methods wmt_evdev_methods = {
+	.ev_open = &wmt_ev_open,
+	.ev_close = &wmt_ev_close,
+};
+
+static const struct usb_config wmt_config[WMT_N_TRANSFER] = {
+
+	[WMT_INTR_DT] = {
+		.type = UE_INTERRUPT,
+		.endpoint = UE_ADDR_ANY,
+		.direction = UE_DIR_IN,
+		.flags = { .pipe_bof = 1, .short_xfer_ok = 1 },
+		.bufsize = WMT_BSIZE,
+		.callback = &wmt_intr_callback,
+	},
+};
+
+static int
+wmt_probe(device_t dev)
+{
+	struct usb_attach_arg *uaa = device_get_ivars(dev);
+	void *d_ptr;
+	uint16_t d_len;
+	int err;
+
+	if (uaa->usb_mode != USB_MODE_HOST)
+		return (ENXIO);
+
+	if (uaa->info.bInterfaceClass != UICLASS_HID)
+		return (ENXIO);
+
+	err = usbd_req_get_hid_desc(uaa->device, NULL,
+	    &d_ptr, &d_len, M_TEMP, uaa->info.bIfaceIndex);
+
+	if (err)
+		return (ENXIO);
+
+	if (wmt_hid_test(d_ptr, d_len))
+		err = BUS_PROBE_DEFAULT;
+	else
+		err = ENXIO;
+
+	free(d_ptr, M_TEMP);
+	return (err);
+}
+
+static int
+wmt_attach(device_t dev)
+{
+	struct usb_attach_arg *uaa = device_get_ivars(dev);
+	struct wmt_softc *sc = device_get_softc(dev);
+	size_t i;
+	int err;
+
+	device_set_usb_desc(dev);
+	sc->dev = dev;
+	sc->udev = uaa->device;
+	sc->iface_no = uaa->info.bIfaceNum;
+	sc->iface_index = uaa->info.bIfaceIndex;
+
+	/* Get HID descriptor */
+	if (usbd_req_get_hid_desc(uaa->device, NULL, &sc->repdesc_ptr,
+	    &sc->repdesc_size, M_TEMP, uaa->info.bIfaceIndex) !=
+	    USB_ERR_NORMAL_COMPLETION)
+		return (ENXIO);
+
+	mtx_init(&sc->sc_mtx, "wmt lock", NULL, MTX_DEF | MTX_RECURSE);
+
+	/* Get HID report descriptor length */
+	sc->isize = hid_report_size
+	    (sc->repdesc_ptr, sc->repdesc_size, hid_input, &sc->iid);
+	sc->fsize = hid_report_size
+	    (sc->repdesc_ptr, sc->repdesc_size, hid_feature, &sc->fid);
+
+	if (sc->isize <= 0 || sc->isize > WMT_BSIZE) {
+		DPRINTF("wmt_attach: input size invalid or too large: %d\n",
+		    sc->isize);
+		goto detach;
+	}
+	if (sc->fsize <= 0 || sc->fsize > WMT_BSIZE) {
+		DPRINTF("wmt_attach: feature size invalid or too large: %d\n",
+		    sc->fsize);
+		goto detach;
+	}
+
+	err = usbd_req_set_protocol(uaa->device, NULL,
+	    uaa->info.bIfaceIndex, 1);
+
+	err = usbd_transfer_setup(uaa->device, &uaa->info.bIfaceIndex,
+	    sc->xfer, wmt_config, WMT_N_TRANSFER, sc, &sc->sc_mtx);
+	if (err) {
+		DPRINTF("usbd_transfer_setup error=%s\n", usbd_errstr(err));
+		goto detach;
+	}
+#ifdef WMT_FIFO_ENABLE
+	err = usb_fifo_attach(uaa->device, sc, &sc->sc_mtx,
+	    &wmt_fifo_methods, &sc->fifo, device_get_unit(dev), -1,
+	    uaa->info.bIfaceIndex, UID_ROOT, GID_OPERATOR, 0644);
+	if (err) {
+		DPRINTF("usb_fifo_attach error=%s\n", usbd_errstr(err));
+		goto detach;
+	}
+#endif
+
+	wmt_hid_parse(sc);
+
+	sc->evdev = evdev_alloc();
+
+	evdev_set_name(sc->evdev, device_get_desc(dev));
+	evdev_set_serial(sc->evdev, "0");
+	evdev_set_methods(sc->evdev, sc, &wmt_evdev_methods);
+	evdev_support_prop(sc->evdev, INPUT_PROP_DIRECT);
+	evdev_support_event(sc->evdev, EV_SYN);
+	evdev_support_event(sc->evdev, EV_ABS);
+	evdev_set_flag(sc->evdev, EVDEV_FLAG_MT_STCOMPAT);
+
+	/* Report absolute contacts and axes information */
+	for (i = 0; i < WMT_N_USAGES; i++)
+		if (WMT_ABSINFO_IS_SET(&sc->ai[i]))
+			evdev_support_abs(sc->evdev, wmt_hid_map[i].code,
+			    (struct input_absinfo *)&sc->ai[i]);
+
+	err = evdev_register(dev, sc->evdev);
+	if (err)
+		goto detach;
+
+	return (0);
+
+detach:
+	if (sc->repdesc_ptr)
+		free(sc->repdesc_ptr, M_TEMP);
+
+	wmt_detach(dev);
+	return (ENXIO);
+}
+
+static int
+wmt_detach(device_t dev)
+{
+	struct wmt_softc *sc = device_get_softc(dev);
+
+	/* Stop intr transfer if running */
+	wmt_ev_close(sc->evdev, sc);
+
+	evdev_unregister(dev, sc->evdev);
+	evdev_free(sc->evdev);
+#ifdef WMT_FIFO_ENABLE
+	usb_fifo_detach(&sc->fifo);
+#endif
+	usbd_transfer_unsetup(sc->xfer, WMT_N_TRANSFER);
+	mtx_destroy(&sc->sc_mtx);
+	return (0);
+}
+
+static void
+wmt_process_frame(struct wmt_softc *sc, uint8_t *buf, int len)
+{
+	int32_t slot_data[WMT_N_USAGES];
+	int32_t slot, contact, contacts_count, width, height;
+	uint8_t id;
+	size_t i;
+
+	if (sc->iid) {
+		id = *buf;
+		len--;
+		buf++;
+	} else {
+		id = 0;
+	}
+
+	if (id != sc->report_id)
+		return;
+
+	contacts_count = hid_get_data(buf, len, &sc->ncontacts);
+
+	/* Use protocol Type B for reporting events */
+	for (contact = 0; contact < contacts_count; contact++) {
+
+		memset(slot_data, 0, sizeof(slot_data));
+		for (i = 0; i < WMT_N_USAGES; i++)
+			if (WMT_ABSINFO_IS_SET(&sc->ai[i]))
+				slot_data[i] = hid_get_data(buf, len,
+				    &sc->hid_items[contact][i]);
+
+		slot = evdev_get_mt_slot_by_tracking_id(sc->evdev,
+		    slot_data[WMT_CONTACT_ID]);
+		if (slot == -1) {
+			printf("Slot overflow for contact_id %d",
+			    (int)slot_data[WMT_CONTACT_ID]);
+			continue;
+		}
+
+		if (slot_data[WMT_TIP_SWITCH] == 0) {
+			evdev_push_event(sc->evdev, EV_ABS, ABS_MT_SLOT, slot);
+			evdev_push_event(sc->evdev, EV_ABS, ABS_MT_TRACKING_ID,
+			    -1);
+		} else {
+			/* this finger is in proximity of the sensor */
+			slot_data[WMT_SLOT] = slot;
+
+			/* divided by two to match visual scale of touch */
+			width = slot_data[WMT_WIDTH] >> 1;
+			height = slot_data[WMT_HEIGHT] >> 1;
+			slot_data[WMT_ORIENTATION] = width > height;
+			slot_data[WMT_MAJOR] = width > height ? width : height;
+			slot_data[WMT_MINOR] = width < height ? width : height;
+			for (i = 0; i < WMT_N_USAGES; i++)
+				if (WMT_ABSINFO_IS_SET(&sc->ai[i]))
+					evdev_push_event(sc->evdev, EV_ABS,
+					    wmt_hid_map[i].code, slot_data[i]);
+		}
+	}
+	evdev_sync(sc->evdev);
+}
+
+static void
+wmt_intr_callback(struct usb_xfer *xfer, usb_error_t error)
+{
+	struct wmt_softc *sc = usbd_xfer_softc(xfer);
+	struct usb_page_cache *pc;
+	uint8_t *buf = sc->buf;
+	int len;
+
+	usbd_xfer_status(xfer, &len, NULL, NULL, NULL);
+
+	switch (USB_GET_STATE(xfer)) {
+	case USB_ST_TRANSFERRED:
+		pc = usbd_xfer_get_frame(xfer, 0);
+
+		if (len >= (int)sc->isize || (len > 0 && sc->iid == 0)) {
+			/* limit report length to the maximum */
+			if (len > (int)sc->isize)
+				len = sc->isize;
+
+			usbd_copy_out(pc, 0, buf, len);
+			if (len < sc->isize) {
+				/* make sure we don't process old data */
+				memset(buf + len, 0, sc->isize - len);
+			}
+
+#ifdef WMT_FIFO_ENABLE
+			wmt_put_queue(sc, buf, sc->isize);
+#endif
+			wmt_process_frame(sc, buf, len);
+		} else {
+			/* ignore it */
+			DPRINTF("ignored transfer, %d bytes\n", len);
+		}
+
+	case USB_ST_SETUP:
+tr_setup:
+#if WMT_FIFO_ENABLE
+		/* check if we can put more data into the FIFO */
+		if (usb_fifo_put_bytes_max(sc->fifo.fp[USB_FIFO_RX]) == 0)
+#endif
+			if ((sc->flags & WMT_FLAG_EV_OPENED) == 0)
+				break;
+
+		usbd_xfer_set_frame_len(xfer, 0, sc->isize);
+		usbd_transfer_submit(xfer);
+		break;
+	default:
+		if (error != USB_ERR_CANCELLED) {
+			/* try clear stall first */
+			usbd_xfer_set_stall(xfer);
+			goto tr_setup;
+		}
+		break;
+	}
+}
+
+#if WMT_FIFO_ENABLE
+static void
+wmt_start_read(struct usb_fifo *fifo)
+{
+	struct wmt_softc *sc = usb_fifo_softc(fifo);
+
+	if (!(sc->flags & WMT_FLAG_EV_OPENED))
+		usbd_transfer_start(sc->xfer[WMT_INTR_DT]);
+	sc->flags |= WMT_FLAG_RD_STARTED;
+}
+
+static void
+wmt_stop_read(struct usb_fifo *fifo)
+{
+	struct wmt_softc *sc = usb_fifo_softc(fifo);
+
+	if (!(sc->flags & WMT_FLAG_EV_OPENED))
+		usbd_transfer_stop(sc->xfer[WMT_INTR_DT]);
+	sc->flags &= ~WMT_FLAG_RD_STARTED;
+}
+
+static void
+wmt_put_queue(struct wmt_softc *sc, uint8_t *buf, usb_size_t len)
+{
+
+	usb_fifo_put_data_linear(sc->fifo.fp[USB_FIFO_RX], buf, len, 1);
+}
+
+static int
+wmt_get_report(struct wmt_softc *sc, uint8_t type, uint8_t id,
+    void *kern_data, void *user_data, uint16_t len)
+{
+	int err;
+	uint8_t free_data = 0;
+
+	if (kern_data == NULL) {
+		kern_data = malloc(len, M_USBDEV, M_WAITOK);
+		if (kern_data == NULL) {
+			err = ENOMEM;
+			goto done;
+		}
+		free_data = 1;
+	}
+	err = usbd_req_get_report(sc->udev, NULL, kern_data, len,
+	    sc->iface_index, type, id);
+	if (err) {
+		err = ENXIO;
+		goto done;
+	}
+	if (user_data) {
+		/* dummy buffer */
+		err = copyout(kern_data, user_data, len);
+		if (err)
+			goto done;
+	}
+done:
+	if (free_data)
+		free(kern_data, M_USBDEV);
+
+	return (err);
+}
+
+
+
+static int
+wmt_open(struct usb_fifo *fifo, int fflags)
+{
+	/*
+	 * The buffers are one byte larger than maximum so that one
+	 * can detect too large read/writes and short transfers:
+	 */
+	if (fflags & FREAD) {
+		struct wmt_softc *sc = usb_fifo_softc(fifo);
+		if (sc->flags & WMT_FLAG_OPENED)
+			return (EBUSY);
+		if (usb_fifo_alloc_buffer(fifo,
+		    sc->isize + 1, WMT_FRAME_NUM))
+			return (ENOMEM);
+
+		sc->flags |= WMT_FLAG_OPENED;
+	}
+	return (0);
+}
+
+static void
+wmt_close(struct usb_fifo *fifo, int fflags)
+{
+	if (fflags & (FREAD)) {
+		struct wmt_softc *sc = usb_fifo_softc(fifo);
+		sc->flags &= ~(WMT_FLAG_OPENED);
+		usb_fifo_free_buffer(fifo);
+	}
+}
+
+static int
+wmt_ioctl(struct usb_fifo *fifo, u_long cmd, void *addr, int fflags)
+{
+	struct wmt_softc *sc = usb_fifo_softc(fifo);
+	struct usb_gen_descriptor *ugd;
+	uint32_t size;
+	int error = 0;
+	uint8_t id;
+
+	switch (cmd) {
+	case USB_GET_REPORT_DESC:
+		ugd = addr;
+		if (sc->repdesc_size > ugd->ugd_maxlen) {
+			size = ugd->ugd_maxlen;
+		} else {
+			size = sc->repdesc_size;
+		}
+		ugd->ugd_actlen = size;
+		if (ugd->ugd_data == NULL)
+			break;		/* descriptor length only */
+		error = copyout(sc->repdesc_ptr, ugd->ugd_data, size);
+		break;
+
+	case USB_SET_IMMED:
+		if (!(fflags & FREAD)) {
+			error = EPERM;
+			break;
+		}
+		error = EINVAL;
+		break;
+
+	case USB_GET_REPORT:
+		if (!(fflags & FREAD)) {
+			error = EPERM;
+			break;
+		}
+		ugd = addr;
+		switch (ugd->ugd_report_type) {
+		case UHID_INPUT_REPORT:
+			size = sc->isize;
+			id = sc->iid;
+			break;
+		case UHID_FEATURE_REPORT:
+			size = sc->fsize;
+			id = sc->fid;
+			break;
+		case UHID_OUTPUT_REPORT:
+		default:
+			return (EINVAL);
+		}
+		if (id != 0)
+			copyin(ugd->ugd_data, &id, 1);
+		error = wmt_get_report(sc, ugd->ugd_report_type, id,
+		    sc->buf, ugd->ugd_data, imin(ugd->ugd_maxlen, size));
+		break;
+
+	case USB_SET_REPORT:
+		if (!(fflags & FWRITE)) {
+			error = EPERM;
+			break;
+		}
+		error = EINVAL;
+		break;
+
+	case USB_GET_REPORT_ID:
+		*(int *)addr = 0;	/* XXX: we only support reportid 0? */
+		break;
+
+	default:
+		error = EINVAL;
+		break;
+	}
+	return (error);
+}
+#endif
+
+static void
+wmt_ev_close(struct evdev_dev *evdev, void *ev_softc)
+{
+	struct wmt_softc *sc = (struct wmt_softc *)ev_softc;
+
+	mtx_lock(&sc->sc_mtx);
+	if (!(sc->flags & WMT_FLAG_RD_STARTED))
+		usbd_transfer_stop(sc->xfer[WMT_INTR_DT]);
+	sc->flags &= ~(WMT_FLAG_EV_OPENED);
+	mtx_unlock(&sc->sc_mtx);
+}
+
+static int
+wmt_ev_open(struct evdev_dev *evdev, void *ev_softc)
+{
+	struct wmt_softc *sc = (struct wmt_softc *)ev_softc;
+
+	mtx_lock(&sc->sc_mtx);
+	if (!(sc->flags & WMT_FLAG_RD_STARTED))
+		usbd_transfer_start(sc->xfer[WMT_INTR_DT]);
+	sc->flags |= WMT_FLAG_EV_OPENED;
+	mtx_unlock(&sc->sc_mtx);
+
+	return (0);
+}
+
+
+static uint32_t
+wmt_hid_test(const void *d_ptr, uint16_t d_len)
+{
+	struct hid_data *hd;
+	struct hid_item hi;
+	int mdepth;
+	uint32_t found;
+
+	hd = hid_start_parse(d_ptr, d_len, 1 << hid_feature);
+	if (hd == NULL)
+		return (0);
+
+	mdepth = 0;
+	found = 0;
+
+	while (hid_get_item(hd, &hi)) {
+		switch (hi.kind) {
+		case hid_collection:
+			if (mdepth != 0)
+				mdepth++;
+			else if (hi.collection == 1 &&
+			     hi.usage ==
+			      HID_USAGE2(HUP_DIGITIZERS, HUD_TOUCHSCREEN))
+				mdepth++;
+			break;
+		case hid_endcollection:
+			if (mdepth != 0)
+				mdepth--;
+			break;
+		case hid_feature:
+			if (mdepth == 0)
+				break;
+			if (hi.usage == HID_USAGE2(HUP_DIGITIZERS, HUD_CONTACT_COUNT_MAX) &&
+			    (hi.flags & (HIO_CONST|HIO_VARIABLE|HIO_RELATIVE)) == HIO_VARIABLE)
+				found = hi.logical_maximum;
+			break;
+		default:
+			break;
+		}
+	}
+	hid_end_parse(hd);
+	return (found);
+}
+
+static void
+hid_item_to_absinfo(struct hid_item *hi, struct input_absinfo *ia)
+{
+	/*
+	 * hid unit scaling table according to HID Usage Table Review
+	 * Request 39 Tbl 17 http://www.usb.org/developers/hidpage/HUTRR39b.pdf
+	 * Modified to do cm to 1/mm conversion.
+	 */
+	static const int64_t scale[][2] = {
+	    { 2, 20 },		/* 0x00 */
+	    { 2, 200 },		/* 0x01 */
+	    { 2, 2000 },	/* 0x02 */
+	    { 2, 20000 },	/* 0x03 */
+	    { 2, 200000 },	/* 0x04 */
+	    { 2, 2000000 },	/* 0x05 */
+	    { 2, 20000000 },	/* 0x06 */
+	    { 2, 200000000 },	/* 0x07 */
+	    { 10000000, 1 },	/* 0x08 */
+	    { 1000000, 1 },	/* 0x09 */
+	    { 100000, 1 },	/* 0x0A */
+	    { 10000, 1 },	/* 0x0B */
+	    { 1000, 1 },	/* 0x0C */
+	    { 100, 1 },		/* 0x0D */
+	    { 10, 1 },		/* 0x0E */
+	    { 2, 2 },		/* 0x0F */
+	};
+	int64_t logical_size, physical_size, resolution;
+
+	if (WMT_ABSINFO_IS_SET(ia))
+		return;
+
+	memset(ia, 0, sizeof(*ia));
+	ia->maximum = hi->logical_maximum;
+	ia->minimum = hi->logical_minimum;
+#define HIUU_CENTIMETER 0x11
+	if (hi->unit == HIUU_CENTIMETER &&
+	    hi->logical_maximum > hi->logical_minimum &&
+	    hi->physical_maximum > hi->physical_minimum) {
+		logical_size = (int64_t)hi->logical_maximum -
+		    (int64_t)hi->logical_minimum + 1;
+		physical_size = (int64_t)hi->physical_maximum -
+		    (int64_t)hi->physical_minimum + 1;
+
+		if (hi->unit_exponent >= 0 &&
+		    hi->unit_exponent < nitems(scale)) {
+			resolution = ((scale[hi->unit_exponent][0] / 2) +
+			    logical_size * scale[hi->unit_exponent][0]) /
+			    (physical_size * scale[hi->unit_exponent][1]);
+			if (resolution <= INT32_MAX)
+				ia->resolution = resolution;
+		}
+	}
+}
+
+static void
+wmt_hid_parse(struct wmt_softc *sc)
+{
+	struct hid_data *hd;
+	struct hid_item hi;
+	int mdepth, touch_coll, finger_coll;
+	size_t i;
+	int32_t finger_idx;
+
+	finger_idx = mdepth = touch_coll = finger_coll = 0;
+
+	hd = hid_start_parse
+	    (sc->repdesc_ptr, sc->repdesc_size, 1 << hid_input);
+	if (hd == NULL)
+		return;
+
+	for (i = 0; i < WMT_N_USAGES; i++)
+		sc->ai[i] = WMT_ABSINFO_RESET;
+
+	while (hid_get_item(hd, &hi)) {
+		switch (hi.kind) {
+		case hid_collection:
+			if (hi.collection == 1 && mdepth == 0 &&
+			    hi.usage ==
+			      HID_USAGE2(HUP_DIGITIZERS, HUD_TOUCHSCREEN))
+				touch_coll = 1;
+			if (hi.collection == 2 && mdepth == 1 &&
+			    hi.usage == HID_USAGE2(HUP_DIGITIZERS, HUD_FINGER)) {
+				finger_coll = 1;
+				sc->report_id = hi.report_ID;
+			}
+			mdepth++;
+			break;
+		case hid_endcollection:
+			if (mdepth != 0)
+				mdepth--;
+			if (mdepth == 1 && finger_coll == 1) {
+				finger_coll = 0;
+				++finger_idx;
+			}
+			if (mdepth == 0 && touch_coll == 1)
+				touch_coll = 0;
+			break;
+		case hid_input:
+			if ((hi.flags & (HIO_CONST|HIO_VARIABLE|HIO_RELATIVE))
+			    != HIO_VARIABLE)
+				break;
+			if (touch_coll == 1 && mdepth == 1) {
+				sc->ncontacts = hi.loc;
+				break;
+			}
+
+			if (finger_coll == 0 || mdepth != 2)
+				break;
+			if (finger_idx >= MAX_MT_SLOTS) {
+				DPRINTF("Finger %d ignored\n", finger_idx);
+				break;
+			}
+
+			if (hi.usage ==
+			    HID_USAGE2(HUP_DIGITIZERS, HUD_TIP_SWITCH))
+				sc->flags |= WMT_FLAG_TIP_SWITCH;
+
+			for (i = 0; i < WMT_N_USAGES; i++) {
+				if (hi.usage == wmt_hid_map[i].usage &&
+				    sc->hid_items[finger_idx][i].size == 0) {
+					sc->hid_items[finger_idx][i] = hi.loc;
+					hid_item_to_absinfo(&hi, &sc->ai[i]);
+					break;
+				}
+			}
+			break;
+		default:
+			break;
+		}
+	}
+	hid_end_parse(hd);
+
+	sc->ai[WMT_SLOT] =
+	    (struct input_absinfo) { .maximum = finger_idx - 1 };
+	if (WMT_ABSINFO_IS_SET(&sc->ai[WMT_WIDTH]) &&
+	    WMT_ABSINFO_IS_SET(&sc->ai[WMT_HEIGHT]))
+		sc->ai[WMT_ORIENTATION] =
+		    (struct input_absinfo) { .maximum = 1 };
+
+	/* Announce information about the pointer device */
+	device_printf(sc->dev,
+	    "%d contacts and [%s%s%s%s]. Report range [%d:%d] - [%d:%d]\n",
+	    (int)finger_idx,
+	    WMT_ABSINFO_IS_SET(&sc->ai[WMT_CONFIDENCE]) ? "C" : "",
+	    WMT_ABSINFO_IS_SET(&sc->ai[WMT_WIDTH]) ? "W" : "",
+	    WMT_ABSINFO_IS_SET(&sc->ai[WMT_HEIGHT]) ? "H" : "",
+	    WMT_ABSINFO_IS_SET(&sc->ai[WMT_PRESSURE]) ? "P" : "",
+	    (int)sc->ai[WMT_X].minimum, (int)sc->ai[WMT_Y].minimum,
+	    (int)sc->ai[WMT_X].maximum, (int)sc->ai[WMT_Y].maximum);
+}
+
+static devclass_t wmt_devclass;
+
+static device_method_t wmt_methods[] = {
+	DEVMETHOD(device_probe, wmt_probe),
+	DEVMETHOD(device_attach, wmt_attach),
+	DEVMETHOD(device_detach, wmt_detach),
+
+	DEVMETHOD_END
+};
+
+static driver_t wmt_driver = {
+	.name = "wmt",
+	.methods = wmt_methods,
+	.size = sizeof(struct wmt_softc),
+};
+
+DRIVER_MODULE(wmt, uhub, wmt_driver, wmt_devclass, NULL, 0);
+MODULE_DEPEND(wmt, usb, 1, 1, 1);
+MODULE_VERSION(wmt, 1);


### PR DESCRIPTION
Build with EVDEV options or use EVDEV kernel config. Recommended to set user permissions for /dev/input/event\* in devfs.rules (libinput can open the device but has problems reading even if compositor is run with setuid).
