### PR TITLE
Support i915 driver reload

### DIFF
--- a/drivers/gpu/drm/linux_fb.c
+++ b/drivers/gpu/drm/linux_fb.c
@@ -216,6 +216,14 @@ fbd_init(struct linux_fb_info *fb_info, int unit)
 	return (0);
 }
 
+static int
+fbd_destroy(struct linux_fb_info *fb_info)
+{
+	destroy_dev(fb_info->fb_cdev);
+
+	return (0);
+}
+
 
 static int
 fb_init(void)
@@ -531,7 +539,7 @@ __register_framebuffer(struct linux_fb_info *fb_info)
 			fb_info->pixmap.access_align = 32;
 			fb_info->pixmap.flags = FB_PIXMAP_DEFAULT;
 		}
-	}	
+	}
 	fb_info->pixmap.offset = 0;
 
 	if (!fb_info->pixmap.blit_x)
@@ -571,14 +579,14 @@ __register_framebuffer(struct linux_fb_info *fb_info)
 	}
 	fb_info_print(&fb_info->fbio);
 
-#if 0	
+#if 0
 	if (!lock_fb_info(fb_info))
 		return -ENODEV;
 	console_lock();
 	fb_notifier_call_chain(FB_EVENT_FB_REGISTERED, &event);
 	console_unlock();
 	unlock_fb_info(fb_info);
-#endif	
+#endif
 	return 0;
 }
 
@@ -633,9 +641,10 @@ __unregister_framebuffer(struct linux_fb_info *fb_info)
 	}
 	if (num_registered_fb == 1)
 		vt_fb_detach(&fb_info->fbio);
+	fbd_destroy(fb_info);
 
 
-#if 0	
+#if 0
 	if (!lock_fb_info(fb_info))
 		return -ENODEV;
 	console_lock();
@@ -647,7 +656,7 @@ __unregister_framebuffer(struct linux_fb_info *fb_info)
 	if (ret)
 		return -EINVAL;
 #endif
-	
+
 	unlink_framebuffer(fb_info);
 	if (fb_info->pixmap.addr &&
 	    (fb_info->pixmap.flags & FB_PIXMAP_DEFAULT))
@@ -657,7 +666,7 @@ __unregister_framebuffer(struct linux_fb_info *fb_info)
 	num_registered_fb--;
 	event.info = fb_info;
 
-#if 0	
+#if 0
 	console_lock();
 	fb_notifier_call_chain(FB_EVENT_FB_UNREGISTERED, &event);
 	console_unlock();
@@ -680,7 +689,7 @@ unregister_framebuffer(struct linux_fb_info *fb_info)
 void
 fb_set_suspend(struct linux_fb_info *info, int state)
 {
-#if 0	
+#if 0
 	struct fb_event event;
 
 	event.info = info;
@@ -691,7 +700,7 @@ fb_set_suspend(struct linux_fb_info *info, int state)
 		info->state = FBINFO_STATE_RUNNING;
 		fb_notifier_call_chain(FB_EVENT_RESUME, &event);
 	}
-#endif	
+#endif
 }
 
 
@@ -830,7 +839,7 @@ fb_sys_read(struct linux_fb_info *info, char *ubuf, size_t count,
 		return -EPERM;
 
 	total_size = info->screen_size ? info->screen_size : info->fix.smem_len;
-	
+
 	if (p >= total_size)
 		return 0;
 

--- a/drivers/gpu/drm/linux_fb.c
+++ b/drivers/gpu/drm/linux_fb.c
@@ -234,11 +234,12 @@ fb_init(void)
 }
 SYSINIT(fb_init, SI_SUB_KLD, SI_ORDER_MIDDLE, fb_init, NULL);
 
-void
-linux_fb_destroy(void)
+static void
+fb_destroy(void)
 {
 	class_destroy(fb_class);
 }
+SYSUNINIT(fb_destroy, SI_SUB_KLD, SI_ORDER_MIDDLE, fb_destroy, NULL);
 
 
 struct linux_fb_info *

--- a/sys/compat/linsysfs/linsysfs_extern.c
+++ b/sys/compat/linsysfs/linsysfs_extern.c
@@ -438,8 +438,10 @@ sysfs_remove_dir(struct kobject *kobj)
 	struct pfs_node *pn = kobj->sd;
 
 	lkpi_sysfs_remove_dir(kobj);
-	if (pn)
+	if (pn) {
 		pfs_destroy(pn);
+		kobj->sd = NULL;
+	}
 }
 
 int

--- a/sys/compat/linsysfs/linsysfs_init.c
+++ b/sys/compat/linsysfs/linsysfs_init.c
@@ -275,14 +275,22 @@ debugfs_attr(PFS_ATTR_ARGS)
 
 static struct pfs_node *classdir;
 struct pfs_node *
-linsysfs_create_class_dir(struct kobject *kobj, const char *name)
+linsysfs_create_class_dir(struct class *class, const char *name)
 {
 	struct pfs_node *pn;
 
 	pn = pfs_create_dir(classdir, name, NULL, NULL, NULL, 0);
-	pn->pn_data = kobj;
-	kobj->sd = pn;
+	pn->pn_data = class;
 	return (pn);
+}
+
+void
+linsysfs_destroy_class_dir(struct class *class)
+{
+	if (class->sd != NULL) {
+		pfs_destroy(class->sd);
+		class->sd = NULL;
+	}
 }
 
 static void

--- a/sys/compat/linuxkpi/common/include/linux/device.h
+++ b/sys/compat/linuxkpi/common/include/linux/device.h
@@ -89,7 +89,7 @@ struct device_driver {
 	const struct dev_pm_ops *pm;
 #ifdef notyet
 	struct driver_private *p;
-#endif	
+#endif
 };
 
 typedef void (*dr_release_t)(struct device *dev, void *res);
@@ -173,6 +173,7 @@ struct device {
 	struct device	*parent;
 	struct list_head irqents;
 	device_t	bsddev;
+	bool		bsddev_attached_here;
 	dev_t		devt;
 	struct class	*class;
 	void		(*release)(struct device *dev);
@@ -188,7 +189,7 @@ struct device {
 					     not all hardware supports
 					     64 bit addresses for consistent
 					     allocations such descriptors. */
-	struct device_node	*of_node; /* associated device tree node */	
+	struct device_node	*of_node; /* associated device tree node */
 	struct fwnode_handle	*fwnode;
 	struct device_driver *driver;	/* which driver has allocated this device */
 	struct dev_pm_info	power;
@@ -268,7 +269,7 @@ show_class_attr_string(struct class *class,
 /*
  * should we create device_printf with corresponding
  * syslog priorities?
- */ 
+ */
 #define	dev_err(dev, fmt, ...)	device_printf((dev)->bsddev, fmt, ##__VA_ARGS__)
 #define	dev_warn(dev, fmt, ...)	device_printf((dev)->bsddev, fmt, ##__VA_ARGS__)
 #define	dev_info(dev, fmt, ...)	device_printf((dev)->bsddev, fmt, ##__VA_ARGS__)
@@ -364,11 +365,23 @@ device_initialize(struct device *dev)
 
 	bsddev = NULL;
 	unit = -1;
+
+	/*
+	 * The bsddev_attached_here flag is used to determine if we
+	 * are responsible for detaching the device too. If the device
+	 * was created/attached elsewhere and we only get it using
+	 * devclass_get_device(), we must not try to detach/delete it:
+	 * it's already done elsewhere.
+	 */
+	dev->bsddev_attached_here = true;
+
 	if (dev->devt) {
 		unit = MINOR(dev->devt);
 		bsddev = devclass_get_device(dev->class->bsdclass, unit);
+		dev->bsddev_attached_here = false;
 	} else if (dev->parent == NULL) {
 		bsddev = devclass_get_device(dev->class->bsdclass, 0);
+		dev->bsddev_attached_here = false;
 	}
 	if (bsddev == NULL && dev->parent != NULL) {
 		bsddev = device_add_child(dev->parent->bsddev,
@@ -387,7 +400,7 @@ device_initialize(struct device *dev)
 
 static inline int
 device_add(struct device *dev)
-{	
+{
 	if (dev->bsddev != NULL) {
 		if (dev->devt == 0)
 			dev->devt = makedev(0, device_get_unit(dev->bsddev));
@@ -471,11 +484,22 @@ device_register(struct device *dev)
 	if (dev->bsddev != NULL)
 		goto done;
 
+	/*
+	 * The bsddev_attached_here flag is used to determine if we
+	 * are responsible for detaching the device too. If the device
+	 * was created/attached elsewhere and we only get it using
+	 * devclass_get_device(), we must not try to detach/delete it:
+	 * it's already done elsewhere.
+	 */
+	dev->bsddev_attached_here = true;
+
 	if (dev->devt) {
 		unit = MINOR(dev->devt);
 		bsddev = devclass_get_device(dev->class->bsdclass, unit);
+		dev->bsddev_attached_here = false;
 	} else if (dev->parent == NULL) {
 		bsddev = devclass_get_device(dev->class->bsdclass, 0);
+		dev->bsddev_attached_here = false;
 	}
 	if (bsddev == NULL && dev->parent != NULL) {
 		bsddev = device_add_child(dev->parent->bsddev,
@@ -502,7 +526,7 @@ device_unregister(struct device *dev)
 	bsddev = dev->bsddev;
 	dev->bsddev = NULL;
 
-	if (bsddev != NULL) {
+	if (bsddev != NULL && dev->bsddev_attached_here) {
 		mtx_lock(&Giant);
 		device_delete_child(device_get_parent(bsddev), bsddev);
 		mtx_unlock(&Giant);
@@ -518,7 +542,7 @@ device_del(struct device *dev)
 	bsddev = dev->bsddev;
 	dev->bsddev = NULL;
 
-	if (bsddev != NULL) {
+	if (bsddev != NULL && dev->bsddev_attached_here) {
 		mtx_lock(&Giant);
 		device_delete_child(device_get_parent(bsddev), bsddev);
 		mtx_unlock(&Giant);
@@ -562,10 +586,10 @@ strpbrk(const char *s, const char *b)
 static struct class hwmon_class = {
 	.name = "hwmon",
 	.owner = THIS_MODULE,
-#ifdef __linux__	
+#ifdef __linux__
 	.dev_groups = hwmon_dev_attr_groups,
 	.dev_release = hwmon_dev_release,
-#endif	
+#endif
 };
 
 #define HWMON_ID_PREFIX "hwmon"

--- a/sys/compat/linuxkpi/common/include/linux/fb.h
+++ b/sys/compat/linuxkpi/common/include/linux/fb.h
@@ -737,7 +737,6 @@ extern void fb_dealloc_cmap(struct fb_cmap *cmap);
 
 /* updated FreeBSD fb_info */
 extern void drm_legacy_fb_init(struct linux_fb_info *fb_info);
-extern void linux_fb_destroy(void);
 extern int fb_get_options(const char *name, char **option);
 
 

--- a/sys/compat/linuxkpi/common/include/linux/sysfs.h
+++ b/sys/compat/linuxkpi/common/include/linux/sysfs.h
@@ -151,7 +151,7 @@ extern void sysfs_remove_bin_file(struct kobject *kobj, const struct bin_attribu
 
 
 extern int sysfs_create_file(struct kobject *kobj, const struct attribute *attr);
-extern void sysfs_remove_file(struct kobject *kobj, const struct attribute *attr);	
+extern void sysfs_remove_file(struct kobject *kobj, const struct attribute *attr);
 
 extern int __must_check sysfs_create_files(struct kobject *kobj, const struct attribute **attr);
 extern void sysfs_remove_files(struct kobject *kobj, const struct attribute **attr);
@@ -178,7 +178,7 @@ void pci_remove_legacy_files(struct pci_bus *b);
 
 
 extern int lkpi_sysfs_create_file(struct kobject *kobj, const struct attribute *attr);
-extern void lkpi_sysfs_remove_file(struct kobject *kobj, const struct attribute *attr);	
+extern void lkpi_sysfs_remove_file(struct kobject *kobj, const struct attribute *attr);
 
 extern int lkpi_sysfs_create_group(struct kobject *kobj, const struct attribute_group *grp);
 extern void lkpi_sysfs_remove_group(struct kobject *kobj, const struct attribute_group *grp);
@@ -188,8 +188,9 @@ extern void sysfs_unmerge_group(struct kobject *kobj, const struct attribute_gro
 extern int lkpi_sysfs_create_dir(struct kobject *kobj);
 extern void lkpi_sysfs_remove_dir(struct kobject *kobj);
 
-
-struct pfs_node *linsysfs_create_class_dir(struct kobject *kobj, const char *name);
+struct class;
+struct pfs_node *linsysfs_create_class_dir(struct class *class, const char *name);
+void linsysfs_destroy_class_dir(struct class *class);
 
 /*
  * Handle our generic '\0' terminated 'C' string.

--- a/sys/compat/linuxkpi/common/src/linux_work.c
+++ b/sys/compat/linuxkpi/common/src/linux_work.c
@@ -32,12 +32,12 @@ get_work_pool_id(struct work_struct *work)
 {
 	unsigned long data = atomic_long_read(&work->data);
 
-#ifdef __notyet__	
+#ifdef __notyet__
 	if (data & WORK_STRUCT_PWQ)
 		return ((struct pool_workqueue *)
 			(data & WORK_STRUCT_WQ_DATA_MASK))->pool->id;
 #endif
-	
+
 	return data >> WORK_OFFQ_POOL_SHIFT;
 }
 
@@ -96,7 +96,7 @@ linux_cancel_work_timer(struct work_struct *work, int delayed)
 {
 	static DECLARE_WAIT_QUEUE_HEAD(wq);
 	int rc;
-	
+
 	do {
 		rc = remove_task(work, delayed);
 		if (__predict_false(rc == -ENOENT)) {
@@ -172,7 +172,7 @@ linux_queue_work(int cpu __unused, struct workqueue_struct *wq, struct work_stru
 	work->taskqueue = wq->taskqueue;
 	taskqueue_enqueue(wq->taskqueue, &work->work_task);
 }
-	
+
 bool
 queue_work_on(int cpu, struct workqueue_struct *wq, struct work_struct *work)
 {
@@ -260,11 +260,10 @@ cancel_delayed_work(struct delayed_work *dwork)
 int
 cancel_delayed_work_sync(struct delayed_work *work)
 {
-        if (work->work.taskqueue &&
-            taskqueue_cancel(work->work.taskqueue, &work->work.work_task, NULL))
-                taskqueue_drain(work->work.taskqueue, &work->work.work_task);
+	while (work->work.taskqueue &&
+	    taskqueue_cancel(work->work.taskqueue, &work->work.work_task,
+	    NULL) != 0)
+		taskqueue_drain(work->work.taskqueue, &work->work.work_task);
 
 	return (linux_cancel_work_timer(&work->work, 1));
 }
-
-

--- a/sys/dev/vt/hw/vga/vt_vga.c
+++ b/sys/dev/vt/hw/vga/vt_vga.c
@@ -1213,8 +1213,15 @@ vga_init(struct vt_device *vd)
 		vd->vd_softc = (void *)&vga_conssoftc;
 	sc = vd->vd_softc;
 
+	/*
+	 * FIXME: REPOSTing causes a failure to stop an Intel GPU during
+	 * the unload of the i915 DRM driver, which later triggers a
+	 * panic.
+	 */
+#if 0
 	if (vd->vd_flags & VDF_DOWNGRADE && vd->vd_video_dev != NULL)
 		vga_pci_repost(vd->vd_video_dev);
+#endif
 
 #if defined(__amd64__) || defined(__i386__)
 	sc->vga_fb_tag = X86_BUS_SPACE_MEM;


### PR DESCRIPTION
With this branch, I can `kldload i915kms` and `kldunload i915kms` several times in a row. After module unload, the console is blank but probably working (so same as HEAD).

All fixes are against DRM core or linuxkpi, so it should help with other drivers as well, but I only tested it with i915.
