### PR TITLE
Remove Linux-specific AcpiGetDataFull() and AcpiGetTableWithSize().

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_bios.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_bios.c
@@ -301,8 +301,9 @@ static bool amdgpu_acpi_vfct_bios(struct amdgpu_device *adev)
 	GOP_VBIOS_CONTENT *vbios;
 	VFCT_IMAGE_HEADER *vhdr;
 
-	if (!ACPI_SUCCESS(acpi_get_table_with_size("VFCT", 1, &hdr, &tbl_size)))
+	if (!ACPI_SUCCESS(acpi_get_table("VFCT", 1, &hdr)))
 		return false;
+	tbl_size = hdr->length;
 	if (tbl_size < sizeof(UEFI_ACPI_VFCT)) {
 		DRM_ERROR("ACPI VFCT table present but broken (too short #1)\n");
 		goto out_unmap;

--- a/drivers/gpu/drm/radeon/radeon_bios.c
+++ b/drivers/gpu/drm/radeon/radeon_bios.c
@@ -603,8 +603,9 @@ static bool radeon_acpi_vfct_bios(struct radeon_device *rdev)
 	GOP_VBIOS_CONTENT *vbios;
 	VFCT_IMAGE_HEADER *vhdr;
 
-	if (!ACPI_SUCCESS(acpi_get_table_with_size("VFCT", 1, &hdr, &tbl_size)))
+	if (!ACPI_SUCCESS(acpi_get_table("VFCT", 1, &hdr)))
 		return false;
+	tbl_size = hdr->length;
 	if (tbl_size < sizeof(UEFI_ACPI_VFCT)) {
 		DRM_ERROR("ACPI VFCT table present but broken (too short #1)\n");
 		goto out_unmap;

--- a/sys/compat/linuxkpi/common/include/acpi/acpixf.h
+++ b/sys/compat/linuxkpi/common/include/acpi/acpixf.h
@@ -946,21 +946,6 @@ void acpi_terminate_debugger(void);
 /*
  * Divergences
  */
-ACPI_GLOBAL(u8, acpi_gbl_permanent_mmap);
-
-ACPI_EXTERNAL_RETURN_STATUS(acpi_status
-			    acpi_get_table_with_size(acpi_string signature,
-						     u32 instance,
-						     struct acpi_table_header
-						     **out_table,
-						     acpi_size *tbl_size))
-
-ACPI_EXTERNAL_RETURN_STATUS(acpi_status
-			    acpi_get_data_full(acpi_handle object,
-					       acpi_object_handler handler,
-					       void **data,
-					       void (*callback)(void *)))
-
 void acpi_run_debugger(char *batch_buffer);
 
 void acpi_set_debugger_thread_id(acpi_thread_id thread_id);

--- a/sys/compat/linuxkpi/common/include/linux/acpi.h
+++ b/sys/compat/linuxkpi/common/include/linux/acpi.h
@@ -54,15 +54,8 @@ acpi_dev_name(struct acpi_device *adev)
 void acpi_scan_drop_device(acpi_handle handle, void *context);
 
 
-int acpi_get_device_data(acpi_handle handle, struct acpi_device **device,
-			 void (*callback)(void *));
-
 struct pci_dev *acpi_get_pci_dev(acpi_handle handle);
 
-static inline int
-acpi_bus_get_device(acpi_handle handle, struct acpi_device **device)
-{
-	return acpi_get_device_data(handle, device, NULL);
-}
+int acpi_bus_get_device(acpi_handle handle, struct acpi_device **device);
 
 #endif

--- a/sys/compat/linuxkpi/common/src/linux_acpi.c
+++ b/sys/compat/linuxkpi/common/src/linux_acpi.c
@@ -13,10 +13,6 @@ extern acpi_handle acpi_lid_handle;
 
 #define acpi_handle_warn(handle, fmt, ...)
 
-extern acpi_status
-AcpiGetDataFull(acpi_handle obj_handle, acpi_object_handler handler,
-		void **data, void (*callback)(void *));
-
 acpi_status
 AcpiGetData(acpi_handle obj_handle, acpi_object_handler handler, void **data);
 
@@ -51,11 +47,6 @@ AcpiGetName(acpi_handle handle, u32 name_type, struct acpi_buffer * buffer);
 acpi_status
 AcpiGetHandle(acpi_handle parent,
     acpi_string pathname, acpi_handle * ret_handle);
-
-acpi_status
-AcpiGetTableWithSize(char *signature,
-		     u32 instance, struct acpi_table_header **out_table,
-		     acpi_size *tbl_size);
 
 
 
@@ -130,14 +121,6 @@ acpi_evaluate_object_typed(acpi_handle handle,
 }
 
 acpi_status
-acpi_get_data_full(acpi_handle obj_handle, acpi_object_handler handler,
-		   void **data, void (*callback)(void *))
-{
-
-	return (AcpiGetDataFull(obj_handle, handler, data, callback));
-}
-
-acpi_status
 acpi_get_data(acpi_handle obj_handle, acpi_object_handler handler, void **data)
 {
 
@@ -168,15 +151,6 @@ acpi_get_handle(acpi_handle parent,
 {
 
 	return (AcpiGetHandle(parent, pathname, ret_handle));
-}
-
-acpi_status
-acpi_get_table_with_size(char *signature,
-	       u32 instance, struct acpi_table_header **out_table,
-	       acpi_size *tbl_size)
-{
-
-	return (AcpiGetTableWithSize(signature, instance, out_table, tbl_size));
 }
 
 bool
@@ -389,16 +363,14 @@ acpi_scan_drop_device(acpi_handle handle, void *context)
 }
 
 int
-acpi_get_device_data(acpi_handle handle, struct acpi_device **device,
-				void (*callback)(void *))
+acpi_bus_get_device(acpi_handle handle, struct acpi_device **device)
 {
 	acpi_status status;
 
 	if (!device)
 		return -EINVAL;
 
-	status = acpi_get_data_full(handle, acpi_scan_drop_device,
-				    (void **)device, callback);
+	status = acpi_get_data(handle, acpi_scan_drop_device, (void **)device);
 	if (ACPI_FAILURE(status) || !*device) {
 		ACPI_DEBUG_PRINT((ACPI_DB_INFO, "No context for object [%p]\n",
 				  handle));

--- a/sys/compat/linuxkpi/common/src/linux_acpi.c
+++ b/sys/compat/linuxkpi/common/src/linux_acpi.c
@@ -48,6 +48,9 @@ acpi_status
 AcpiGetHandle(acpi_handle parent,
     acpi_string pathname, acpi_handle * ret_handle);
 
+acpi_status
+AcpiGetTable(acpi_string signature, u32 instance, struct acpi_table_header **OutTable);
+
 
 
 
@@ -151,6 +154,13 @@ acpi_get_handle(acpi_handle parent,
 {
 
 	return (AcpiGetHandle(parent, pathname, ret_handle));
+}
+
+acpi_status
+acpi_get_table(acpi_string signature, u32 instance, struct acpi_table_header **out_table)
+{
+
+	return (AcpiGetTable(signature, instance, out_table));
 }
 
 bool

--- a/sys/compat/linuxkpi/common/src/linux_acpi.c
+++ b/sys/compat/linuxkpi/common/src/linux_acpi.c
@@ -49,7 +49,7 @@ AcpiGetHandle(acpi_handle parent,
     acpi_string pathname, acpi_handle * ret_handle);
 
 acpi_status
-AcpiGetTable(acpi_string signature, u32 instance, struct acpi_table_header **OutTable);
+AcpiGetTable(acpi_string signature, u32 instance, struct acpi_table_header **out_table);
 
 
 


### PR DESCRIPTION
- AcpiGetDataFull() is unnecessary.
- AcpiGetTableWithSize() is deprecated.
- Add stub for AcpiGetTable().