### PR TITLE
Add set group to video and permission to 0660 for evdev devices.

### DIFF
--- a/sys/dev/evdev/cdev.c
+++ b/sys/dev/evdev/cdev.c
@@ -124,7 +124,7 @@ evdev_open(struct cdev *dev, int oflags, int devtype, struct thread *td)
 	if (ret != 0)
 		evdev_revoke_client(client);
 	/*
-	 * Unlock evdev here because non-sleepable lock held 
+	 * Unlock evdev here because non-sleepable lock held
 	 * while calling devfs_set_cdevpriv upsets WITNESS
 	 */
 	EVDEV_UNLOCK(evdev);
@@ -681,8 +681,8 @@ evdev_cdev_create(struct evdev_dev *evdev)
 	mda.mda_flags = MAKEDEV_WAITOK | MAKEDEV_CHECKNAME;
 	mda.mda_devsw = &evdev_cdevsw;
 	mda.mda_uid = UID_ROOT;
-	mda.mda_gid = GID_WHEEL;
-	mda.mda_mode = 0600;
+	mda.mda_gid = GID_VIDEO;
+	mda.mda_mode = 0660;
 	mda.mda_si_drv1 = evdev;
 
 	/* Try to coexist with cuse-backed input/event devices */


### PR DESCRIPTION
I think this is a good solution for evdev permissions since you won't use evdev without video (graphics) anyway. @mattmacy? 