### PR TITLE
Fix build with "options ACPI_DEBUG".

### DIFF
--- a/sys/compat/linuxkpi/gplv2/src/linux_acpi.c
+++ b/sys/compat/linuxkpi/gplv2/src/linux_acpi.c
@@ -2,6 +2,8 @@
 #include <acpi/button.h>
 #include <linux/pci.h>
 
+#define _COMPONENT	ACPI_OS_SERVICES
+ACPI_MODULE_NAME("linux_acpi")
 
 
 char empty_zero_page[PAGE_SIZE] __aligned(PAGE_SIZE);


### PR DESCRIPTION
If "options ACPI_DEBUG" is in the kernel configuration, it fails to build because couple of things are missing, i.e., _COMPONENT is not defined and ACPI_MODULE_NAME is not set.